### PR TITLE
Use POST method to refresh token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ DB_DATABASE=
 # node -e "console.log(require('crypto').randomBytes(256).toString('base64'));"
 JWT_ACCESS_TOKEN=
 JWT_REFRESH_TOKEN=
+# 7d 5h 3m 1s
+JWT_ACCESS_TOKEN_EXPIRATION_TIME=1h
+JWT_REFRESH_TOKEN_EXPIRATION_TIME=7d
 # Email
 RESEND_TOKEN=
 NOTIFICATION_EMAIL=

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -28,7 +28,7 @@ export class AuthController {
   }
 
   @Public()
-  @Get('refresh')
+  @Post('refresh')
   async refreshToken(@Request() req: any) {
     const [type, token] = req.headers.authorization?.split(' ') ?? [];
     if (type !== 'Bearer' || !token) {

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -66,11 +66,11 @@ export class AuthService {
     return new JwtTokensDto({
       accessToken: await this.jwtService.signAsync(payload, {
         secret: this.configService.get('JWT_ACCESS_TOKEN'),
-        expiresIn: '1h',
+        expiresIn: this.configService.get('JWT_ACCESS_TOKEN_EXPIRATION_TIME', '1h'),
       }),
       refreshToken: await this.jwtService.signAsync(payload, {
         secret: this.configService.get('JWT_REFRESH_TOKEN'),
-        expiresIn: '7d',
+        expiresIn: this.configService.get('JWT_REFRESH_TOKEN_EXPIRATION_TIME', '7d'),
       }),
     });
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed the refresh token endpoint to use the POST method instead of GET for improved request handling.
* **New Features**
  * Added configurable expiration times for JWT access and refresh tokens via environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->