### PR TITLE
Fix deployment issue

### DIFF
--- a/src/modules/appwrite-uploads/appwrite-uploads.service.ts
+++ b/src/modules/appwrite-uploads/appwrite-uploads.service.ts
@@ -28,7 +28,7 @@ export class AppwriteUploadsService {
       const { $id: fileId, name: fileName } = await this.storage.createFile(
         this.bucketId,
         'unique()',
-        new File([fileBuffer], file.originalname, { type: file.mimetype }),
+        new File([fileBuffer as BlobPart], file.originalname, { type: file.mimetype }),
       );
 
       console.log('File uploaded successfully:', fileName);


### PR DESCRIPTION
The latest build has a deployment issue.

src/modules/appwrite-uploads/appwrite-uploads.service.ts:31:19 - error TS2322: Type 'Buffer<ArrayBufferLike>' is not assignable to type 'BlobPart'.
  Type 'Buffer<ArrayBufferLike>' is not assignable to type 'ArrayBufferView<ArrayBuffer>'.
    Types of property 'buffer' are incompatible.
      Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
        Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'.
          Types of property '[Symbol.toStringTag]' are incompatible.
            Type '"SharedArrayBuffer"' is not assignable to type '"ArrayBuffer"'.
31         new File([fileBuffer], file.originalname, { type: file.mimetype }),
                     ~~~~~~~~~~
Found 1 error(s).
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Command "yarn build" exited with 1
Exiting build container`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload process to enhance compatibility and reliability when uploading files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->