### PR TITLE
Restore Unit tests

### DIFF
--- a/.github/workflows/unit-tests-ci.js.yml
+++ b/.github/workflows/unit-tests-ci.js.yml
@@ -1,0 +1,21 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Run unit tests CI
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 21
+    - run: yarn
+    - run: yarn build
+    - run: yarn test

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "setupFilesAfterEnv": ["<rootDir>/jest.setup.ts"]
   }
 }

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -1,0 +1,1 @@
+import './utils/array.extensions';

--- a/src/modules/auth/auth.guard.spec.ts
+++ b/src/modules/auth/auth.guard.spec.ts
@@ -1,0 +1,107 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { AuthGuard } from './auth.guard';
+import { AuthUserMapper } from './auth.user.mapper';
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+  let mockJwtService: any;
+  let mockReflector: any;
+  let mockConfigService: any;
+  let mapper: AuthUserMapper;
+
+  beforeEach(() => {
+    mockJwtService = {
+      verifyAsync: jest.fn(),
+    };
+
+    mockReflector = {
+      getAllAndOverride: jest.fn(),
+    };
+
+    mockConfigService = {
+      get: jest.fn(),
+    };
+
+    mapper = new AuthUserMapper();
+
+    guard = new AuthGuard(mockJwtService, mockReflector, mockConfigService, mapper);
+  });
+
+  function makeExecutionContext(request: any) {
+    return {
+      getHandler: () => ({}),
+      getClass: () => ({}),
+      switchToHttp: () => ({ getRequest: () => request }),
+    } as any;
+  }
+
+  it('allows when route is public', async () => {
+    mockReflector.getAllAndOverride.mockReturnValue(true);
+
+    const ctx = makeExecutionContext({});
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('allows OPTIONS requests', async () => {
+    mockReflector.getAllAndOverride.mockReturnValue(false);
+
+    const request: any = { method: 'OPTIONS' };
+    const ctx = makeExecutionContext(request);
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('throws UnauthorizedException when authorization header is missing', async () => {
+    mockReflector.getAllAndOverride.mockReturnValue(false);
+
+    const request: any = { method: 'GET', headers: {} };
+    const ctx = makeExecutionContext(request);
+
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('throws UnauthorizedException when authorization header is malformed', async () => {
+    mockReflector.getAllAndOverride.mockReturnValue(false);
+
+    const request: any = { method: 'GET', headers: { authorization: 'Bad token' } };
+    const ctx = makeExecutionContext(request);
+
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('throws UnauthorizedException when jwt verification fails', async () => {
+    mockReflector.getAllAndOverride.mockReturnValue(false);
+    mockConfigService.get.mockReturnValue('access-secret');
+    mockJwtService.verifyAsync.mockRejectedValue(new Error('invalid'));
+
+    const request: any = { method: 'GET', headers: { authorization: 'Bearer some-token' } };
+    const ctx = makeExecutionContext(request);
+
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+
+    expect(mockJwtService.verifyAsync).toHaveBeenCalledWith('some-token', {
+      secret: 'access-secret',
+    });
+  });
+
+  it('verifies token and maps payload to request.user on success', async () => {
+    mockReflector.getAllAndOverride.mockReturnValue(false);
+    mockConfigService.get.mockReturnValue('access-secret');
+
+    const payload = { sub: 'user-123', email: 'me@example.com' };
+    mockJwtService.verifyAsync.mockResolvedValue(payload);
+
+    const request: any = { method: 'GET', headers: { authorization: 'Bearer valid-token' } };
+    const ctx = makeExecutionContext(request);
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+
+    expect(mockJwtService.verifyAsync).toHaveBeenCalledWith('valid-token', {
+      secret: 'access-secret',
+    });
+    expect(request.user).toBeDefined();
+    expect(request.user.userId).toBe(payload.sub);
+    expect(request.user.email).toBe(payload.email);
+  });
+});

--- a/src/modules/auth/auth.guard.ts
+++ b/src/modules/auth/auth.guard.ts
@@ -28,7 +28,7 @@ export class AuthGuard implements CanActivate {
     if (request.method === 'OPTIONS') {
       return true;
     }
-    
+
     const token = this.extractTokenFromHeader(request);
     if (!token) {
       throw new UnauthorizedException();

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -1,0 +1,186 @@
+/* eslint-disable */
+import * as bcrypt from 'bcrypt';
+import { UnauthorizedException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { CustomHttpException } from '../../exceptions/custom.exception';
+import { VerificationProcess } from '../users/enums/verification-process.enum';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  const mockUsersRepository = {
+    save: jest.fn(),
+  } as any;
+
+  const mockUsersService = {
+    findOneBy: jest.fn(),
+  } as any;
+
+  const mockJwtService = {
+    signAsync: jest.fn(),
+    verifyAsync: jest.fn(),
+  } as any;
+
+  const mockConfigService = {
+    get: jest.fn(),
+  } as any;
+
+  const mockUserCodeVerificationService = {
+    verifyUserCode: jest.fn(),
+    createAndSendEmailResetVerificationCode: jest.fn(),
+  } as any;
+
+  const user = {
+    id: 'user-id-1',
+    email: 'old@example.com',
+    password: 'hashed-password',
+    isEmailVerified: true,
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockConfigService.get.mockImplementation((key: string, defaultValue?: any) => {
+      if (key === 'JWT_ACCESS_TOKEN') {
+        return 'access-secret';
+      }
+      if (key === 'JWT_REFRESH_TOKEN') {
+        return 'refresh-secret';
+      }
+      if (key === 'JWT_ACCESS_TOKEN_EXPIRATION_TIME') {
+        return '1h';
+      }
+      if (key === 'JWT_REFRESH_TOKEN_EXPIRATION_TIME') {
+        return '7d';
+      }
+
+      return defaultValue;
+    });
+
+    service = new AuthService(
+      mockUsersRepository,
+      mockUsersService,
+      mockJwtService,
+      mockConfigService,
+      mockUserCodeVerificationService,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('signIn', () => {
+    it('throws UnauthorizedException when user not found', async () => {
+
+      await expect(
+        service.signIn('noone@example.com', 'password'),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+
+      expect(mockUsersService.findOneBy).toHaveBeenCalledWith({ email: 'noone@example.com' });
+    });
+
+    it('throws UnauthorizedException when password is incorrect', async () => {
+      mockUsersService.findOneBy.mockResolvedValue(user);
+      jest.spyOn(bcrypt as any, 'compare').mockResolvedValue(false);
+
+      await expect(
+        service.signIn(user.email, 'wrong-password'),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+
+      expect((bcrypt as any).compare).toHaveBeenCalledWith('wrong-password', user.password);
+    });
+
+    it('throws CustomHttpException when email is not verified', async () => {
+      const unverifiedUser = { ...user, isEmailVerified: false };
+      mockUsersService.findOneBy.mockResolvedValue(unverifiedUser);
+      jest.spyOn(bcrypt as any, 'compare').mockResolvedValue(true);
+
+      await expect(
+        service.signIn(unverifiedUser.email, 'password'),
+      ).rejects.toBeInstanceOf(CustomHttpException);
+    });
+
+    it('returns access and refresh tokens on success', async () => {
+      mockUsersService.findOneBy.mockResolvedValue(user);
+      jest.spyOn(bcrypt as any, 'compare').mockResolvedValue(true);
+
+      mockJwtService.signAsync
+        .mockResolvedValueOnce('access-token')
+        .mockResolvedValueOnce('refresh-token');
+
+      const tokens = await service.signIn(user.email, 'password');
+
+      expect(tokens).toHaveProperty('accessToken', 'access-token');
+      expect(tokens).toHaveProperty('refreshToken', 'refresh-token');
+
+      expect(mockJwtService.signAsync).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('refreshToken', () => {
+    it('throws UnauthorizedException when token is invalid', async () => {
+      mockJwtService.verifyAsync.mockRejectedValue(new Error('invalid token'));
+
+      await expect(service.refreshToken('bad-token')).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('returns new tokens when refresh token is valid', async () => {
+      const payload = { sub: user.id, email: user.email };
+      mockJwtService.verifyAsync.mockResolvedValue(payload);
+
+      mockJwtService.signAsync
+        .mockResolvedValueOnce('new-access')
+        .mockResolvedValueOnce('new-refresh');
+
+      const tokens = await service.refreshToken('valid-token');
+
+      expect(tokens).toHaveProperty('accessToken', 'new-access');
+      expect(tokens).toHaveProperty('refreshToken', 'new-refresh');
+
+      expect(mockJwtService.verifyAsync).toHaveBeenCalledWith('valid-token', { secret: 'refresh-secret' });
+    });
+  });
+
+  describe('resetEmail', () => {
+    it('verifies code, updates email and returns new tokens', async () => {
+      const code = '123456';
+      const newEmail = 'new@example.com';
+
+      mockUserCodeVerificationService.verifyUserCode.mockResolvedValue(undefined);
+      mockUsersService.findOneBy.mockResolvedValue({ ...user });
+
+      const savedUser = { ...user, email: newEmail };
+      mockUsersRepository.save.mockResolvedValue(savedUser);
+
+      mockJwtService.signAsync
+        .mockResolvedValueOnce('access-after-reset')
+        .mockResolvedValueOnce('refresh-after-reset');
+
+      const originalEmail = user.email;
+      const tokens = await service.resetEmail(originalEmail, code, newEmail);
+
+      expect(mockUserCodeVerificationService.verifyUserCode).toHaveBeenCalledWith(
+        { email: originalEmail },
+        code,
+        VerificationProcess.USER_EMAIL_RESET,
+      );
+
+      expect(mockUsersRepository.save).toHaveBeenCalled();
+      expect(tokens).toHaveProperty('accessToken', 'access-after-reset');
+      expect(tokens).toHaveProperty('refreshToken', 'refresh-after-reset');
+    });
+  });
+
+  describe('createAndSendEmailResetVerificationCode', () => {
+    it('delegates to userCodeVerificationService', async () => {
+      await service.createAndSendEmailResetVerificationCode('user-id-1', 'me@example.com', 'some-process' as any);
+
+      expect(mockUserCodeVerificationService.createAndSendEmailResetVerificationCode).toHaveBeenCalledWith(
+        'user-id-1',
+        'me@example.com',
+        'some-process',
+      );
+    });
+  });
+});

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -27,7 +27,7 @@ export class AuthService {
 
   async signIn(email: string, password: string): Promise<any> {
     const user = await this.usersService.findOneBy({ email });
-    if (user === null) {
+    if (!user) {
       throw new UnauthorizedException();
     }
 

--- a/src/modules/board-columns/board-columns.service.spec.ts
+++ b/src/modules/board-columns/board-columns.service.spec.ts
@@ -1,0 +1,178 @@
+/* eslint-disable */
+import { BadRequestException, ConflictException } from '@nestjs/common';
+import { BoardColumnsService } from './board-columns.service';
+import { BoardColumn } from './entities/board-column.entity';
+
+describe('BoardColumnsService', () => {
+  let service: BoardColumnsService;
+
+  const mockBoardColumnsRepository: any = {
+    find: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    findBy: jest.fn(),
+    upsert: jest.fn(),
+    findOneBy: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  const mockBoardsRepository: any = {
+    existsBy: jest.fn(),
+  };
+
+  const userId = 'user-1';
+  const boardId = 'board-1';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    service = new BoardColumnsService(mockBoardColumnsRepository, mockBoardsRepository);
+  });
+
+  describe('create', () => {
+    it('throws BadRequestException when board does not exist', async () => {
+      mockBoardsRepository.existsBy.mockResolvedValue(false);
+
+      await expect(
+        service.create({ name: 'Col', boardId } as any, userId),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(mockBoardsRepository.existsBy).toHaveBeenCalledWith({ id: boardId, user: { id: userId } });
+    });
+
+    it('throws ConflictException when column name already exists', async () => {
+      mockBoardsRepository.existsBy.mockResolvedValue(true);
+      // return one existing column with same name
+      mockBoardColumnsRepository.find.mockResolvedValue([{ name: 'Col', order: 0 }]);
+
+      await expect(
+        service.create({ name: 'Col', boardId } as any, userId),
+      ).rejects.toBeInstanceOf(ConflictException);
+
+      expect(mockBoardColumnsRepository.find).toHaveBeenCalled();
+    });
+
+    it('creates and saves a new column when data is valid', async () => {
+      mockBoardsRepository.existsBy.mockResolvedValue(true);
+      mockBoardColumnsRepository.find.mockResolvedValue([]);
+
+      const createdEntity = { id: 'col-1', name: 'Col', order: 0, board: { id: boardId } } as BoardColumn;
+      mockBoardColumnsRepository.create.mockReturnValue(createdEntity);
+      mockBoardColumnsRepository.save.mockResolvedValue(createdEntity);
+
+      const result = await service.create({ name: 'Col', boardId } as any, userId);
+
+      expect(mockBoardColumnsRepository.create).toHaveBeenCalledWith({ name: 'Col', board: { id: boardId }, order: 0 });
+      expect(mockBoardColumnsRepository.save).toHaveBeenCalledWith(createdEntity);
+      expect(result).toBe(createdEntity);
+    });
+  });
+
+  describe('createDefaultBoardColumns', () => {
+    it('throws BadRequestException when board does not exist', async () => {
+      mockBoardsRepository.existsBy.mockResolvedValue(false);
+
+      await expect(service.createDefaultBoardColumns(boardId, userId)).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('creates and saves default columns when board exists', async () => {
+      mockBoardsRepository.existsBy.mockResolvedValue(true);
+
+      const saved = [
+        { id: '1', name: 'Wishlist' },
+        { id: '2', name: 'Applied' },
+      ] as BoardColumn[];
+      mockBoardColumnsRepository.create.mockImplementation((v) => v);
+      mockBoardColumnsRepository.save.mockResolvedValue(saved);
+
+      const result = await service.createDefaultBoardColumns(boardId, userId);
+
+      expect(mockBoardColumnsRepository.create).toHaveBeenCalled();
+      expect(mockBoardColumnsRepository.save).toHaveBeenCalledWith(expect.any(Array));
+      expect(result).toBe(saved);
+    });
+  });
+
+  describe('rearrangeColumns', () => {
+    it('throws BadRequestException when board does not exist', async () => {
+      mockBoardsRepository.existsBy.mockResolvedValue(false);
+      const columnsIds = ['col-1', 'col-2'];
+      await expect(service.rearrangeColumns(boardId, columnsIds, userId)).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws BadRequestException when provided list is empty', async () => {
+      mockBoardsRepository.existsBy.mockResolvedValue(true);
+
+      const columnsIds = [];
+
+      await expect(service.rearrangeColumns(boardId, columnsIds, userId)).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws BadRequestException when list has duplicates', async () => {
+      mockBoardsRepository.existsBy.mockResolvedValue(true);
+
+      const columnsIds = ['col-1', 'col-2'];
+
+      await expect(service.rearrangeColumns(boardId, columnsIds, userId)).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws BadRequestException when list does not match db columns', async () => {
+      mockBoardsRepository.existsBy.mockResolvedValue(true);
+
+      const dbColumns = [{ id: 'col-1' }, { id: 'col-2' }];
+      mockBoardColumnsRepository.findBy.mockResolvedValue(dbColumns);
+
+      const ctxColumns: any = ['col-1', 'random-col'];
+
+      await expect(service.rearrangeColumns(boardId, ctxColumns, userId)).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('updates order and upserts when list is valid', async () => {
+      mockBoardsRepository.existsBy.mockResolvedValue(true);
+
+      const dbColumns = [{ id: 'col-1', order: 0 }, { id: 'col-2', order: 1 }];
+      mockBoardColumnsRepository.findBy.mockResolvedValue(dbColumns);
+
+      const ctxColumns: any = ['col-2', 'col-1'];
+
+      await service.rearrangeColumns(boardId, ctxColumns, userId);
+
+      // After rearrange, orders should be updated and upsert called
+      expect(mockBoardColumnsRepository.upsert).toHaveBeenCalledWith(expect.any(Array), ['id']);
+    });
+  });
+
+  describe('update and remove (via findById)', () => {
+    it('update assigns values and saves', async () => {
+      const columnId = 'col-1';
+      const existing = { id: columnId, name: 'Old' };
+      mockBoardColumnsRepository.findOneBy.mockResolvedValue(existing);
+      mockBoardColumnsRepository.save.mockResolvedValue({ ...existing, name: 'New' });
+
+      const result = await service.update(columnId, { name: 'New' } as any, userId);
+
+      expect(mockBoardColumnsRepository.findOneBy).toHaveBeenCalledWith({ id: columnId, board: { user: { id: userId } } });
+      expect(mockBoardColumnsRepository.save).toHaveBeenCalledWith(existing);
+      expect(result.name).toBe('New');
+    });
+
+    it('remove finds and removes the entity', async () => {
+      const columnId = 'col-2';
+      const existing = { id: columnId, name: 'X' };
+      mockBoardColumnsRepository.findOneBy.mockResolvedValue(existing);
+      mockBoardColumnsRepository.remove.mockResolvedValue(existing);
+
+      const result = await service.remove(columnId, userId);
+
+      expect(mockBoardColumnsRepository.findOneBy).toHaveBeenCalledWith({ id: columnId, board: { user: { id: userId } } });
+      expect(mockBoardColumnsRepository.remove).toHaveBeenCalledWith(existing);
+      expect(result).toBe(existing);
+    });
+
+    it('findById throws when not found', async () => {
+      mockBoardColumnsRepository.findOneBy.mockResolvedValue(undefined);
+
+      await expect(service.update('missing', { name: 'X' } as any, userId)).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+});

--- a/src/modules/board-columns/board-columns.service.ts
+++ b/src/modules/board-columns/board-columns.service.ts
@@ -25,7 +25,7 @@ export class BoardColumnsService {
       throw new BadRequestException(ExceptionMessages.doesNotExist(Board.name));
     }
 
-    // take:1 operator throws an eror "column distinctAlias.BoardColumn_id does not exist"
+    // take:1 operator throws an error "column distinctAlias.BoardColumn_id does not exist"
     const dbColumns = await this.boardColumnsRepository.find({
       select: { order: true, name: true },
       where: { board: { id: dto.boardId } },
@@ -77,6 +77,10 @@ export class BoardColumnsService {
     const dbColumns = await this.boardColumnsRepository.findBy({
       board: { id: boardId },
     });
+
+    if (!dbColumns || dbColumns.length === 0) {
+      throw new BadRequestException('There are no columns in this board.');
+    }
 
     const dbColumnsIds = dbColumns.map((x) => x.id);
     this.validateRearrange(columnsIds, dbColumnsIds);

--- a/src/modules/boards/boards.controller.spec.ts
+++ b/src/modules/boards/boards.controller.spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BoardsController } from './boards.controller';
+import { BoardsService } from './boards.service';
+import { BoardMapper } from './boards.mapper';
+
+describe('BoardsController', () => {
+  let controller: BoardsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: BoardsService, useValue: {} },
+        { provide: BoardMapper, useValue: {} },
+      ],
+      controllers: [BoardsController],
+    }).compile();
+
+    controller = module.get<BoardsController>(BoardsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/boards/boards.service.spec.ts
+++ b/src/modules/boards/boards.service.spec.ts
@@ -1,0 +1,152 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BoardsService } from './boards.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Board } from './entities/board.entity';
+import { User } from '../users/entities/user.entity';
+import { BoardColumnsService } from '../board-columns/board-columns.service';
+import { UserRole } from '../users/enums/user-role.enum';
+import { Repository } from 'typeorm';
+import { newGuid } from '../../utils/guid';
+import { CreateBoardDto } from './dtos/create-board.dto';
+import { FindBoardDto } from './dtos/find-board.dto';
+import { BoardColumn } from '../board-columns/entities/board-column.entity';
+import { ExceptionMessages } from '../../exceptions/exception-messages';
+import { JobApplication } from '../job-applications/entities/job-application.entity';
+
+describe('BoardsService', () => {
+  let service: BoardsService;
+  let boardColumnsService: BoardColumnsService;
+  let boardsRepository: Repository<Board>;
+  let usersRepository: Repository<User>;
+
+  const validUser = {
+    id: newGuid(),
+    email: 'user@email.com',
+    role: UserRole.USER,
+  } as User;
+
+  const validBoard = {
+    id: newGuid(),
+    name: 'Job Search 2024',
+    user: validUser,
+  } as Board;
+
+  const validBoardColumns = [{ id: newGuid(), name: 'Wishlist' } as BoardColumn];
+
+  beforeEach(async () => {
+    const usersRepositoryMock = {
+      findOneBy: jest.fn().mockImplementation(() => Promise.resolve(validUser)),
+      existsBy: jest.fn().mockImplementation(() => Promise.resolve(validUser)),
+      save: jest.fn().mockImplementation(() => Promise.resolve(validUser)),
+      remove: jest.fn().mockImplementation(() => Promise.resolve(validUser)),
+    };
+
+    const boardsRepositoryMock = {
+      findOneBy: jest.fn().mockImplementation(() => Promise.resolve(validBoard)),
+      findBy: jest.fn().mockImplementation(() => Promise.resolve([validBoard])),
+      find: jest.fn().mockImplementation(() => Promise.resolve([validBoard])),
+      create: jest.fn().mockImplementation(() => Promise.resolve(validBoard)),
+      save: jest.fn().mockImplementation(() => Promise.resolve(validBoard)),
+      remove: jest.fn().mockImplementation(() => Promise.resolve(validBoard)),
+    };
+
+    const jobApplicationRepositoryMock = {
+      find: jest.fn().mockImplementation(() => Promise.resolve([])),
+    };
+
+    const boardColumnsServiceMock = {
+      findColumns: jest.fn().mockImplementation(() => Promise.resolve(validBoardColumns)),
+      createDefaultBoardColumns: jest
+        .fn()
+        .mockImplementation(() => Promise.resolve(validBoardColumns)),
+    };
+
+    const boardRepositoryToken = getRepositoryToken(Board);
+    const userRepositoryToken = getRepositoryToken(User);
+    const jobApplicationsRepository = getRepositoryToken(JobApplication);
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BoardsService,
+        { provide: boardRepositoryToken, useValue: boardsRepositoryMock },
+        { provide: userRepositoryToken, useValue: usersRepositoryMock },
+        { provide: BoardColumnsService, useValue: boardColumnsServiceMock },
+        { provide: jobApplicationsRepository, useValue: jobApplicationRepositoryMock },
+      ],
+    }).compile();
+
+    service = module.get<BoardsService>(BoardsService);
+    boardColumnsService = module.get<BoardColumnsService>(BoardColumnsService);
+    boardsRepository = module.get<Repository<Board>>(boardRepositoryToken);
+    usersRepository = module.get<Repository<User>>(userRepositoryToken);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+    expect(boardColumnsService).toBeDefined();
+    expect(boardsRepository).toBeDefined();
+    expect(usersRepository).toBeDefined();
+  });
+
+  it('should save a board with default columns', async () => {
+    // Arrange
+    const dto = { name: validBoard.name } as CreateBoardDto;
+
+    // Act
+    const result = await service.create(dto, validUser.id);
+
+    // Assert
+    expect(result).toEqual(validBoard);
+    expect(result.columns).toEqual(validBoardColumns);
+    expect(boardColumnsService.createDefaultBoardColumns).toHaveBeenCalled();
+  });
+
+  it('should throw an exception on create()', async () => {
+    // Arrange
+    const dto = { name: validBoard.name } as CreateBoardDto;
+    jest.spyOn(usersRepository, 'existsBy').mockImplementation(() => null);
+
+    // Act & Assert
+    expect(() => service.create(dto, validUser.id)).rejects.toThrow(
+      ExceptionMessages.doesNotExist(User.name),
+    );
+  });
+
+  it('should find boards', async () => {
+    const dto = { name: validBoard.name } as FindBoardDto;
+    expect(await service.findBy(dto, validUser.id)).toEqual([validBoard]);
+  });
+
+  it('should throw an exception on findBy()', async () => {
+    // Arrange
+    const dto = { name: validBoard.name } as FindBoardDto;
+    jest.spyOn(usersRepository, 'existsBy').mockImplementation(() => null);
+
+    // Act & Assert
+    expect(() => service.findBy(dto, validUser.id)).rejects.toThrow(
+      ExceptionMessages.doesNotExist(User.name),
+    );
+  });
+
+  it('should find a board with columns', async () => {
+    expect(await service.findOne(validBoard.id, validUser.id)).toEqual({
+      ...validBoard,
+      columns: validBoardColumns,
+    });
+  });
+
+  it('should update a board', async () => {
+    // Act
+    await service.update(validBoard.id, { isArchived: true }, validUser.id);
+
+    // Assert
+    expect(boardsRepository.save).toHaveBeenCalledWith({ ...validBoard, isArchived: true });
+  });
+
+  it('should remove a board', async () => {
+    // Act
+    await service.remove(validBoard.id, validUser.id);
+
+    // Assert
+    expect(boardsRepository.remove).toHaveBeenCalledWith(validBoard);
+  });
+});

--- a/src/modules/companies/companies.service.spec.ts
+++ b/src/modules/companies/companies.service.spec.ts
@@ -1,0 +1,144 @@
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { CompaniesService } from './companies.service';
+import { Company } from './entities/company.entity';
+import { JobApplication } from '../job-applications/entities/job-application.entity';
+import { CreateCompanyDto } from './dtos/create-company.dto';
+import { UpdateCompanyDto } from './dtos/update-company.dto';
+import { AuthUserDto } from '../auth/dtos/auth.user.dto';
+
+type MockRepo<T = any> = Partial<Record<keyof Repository<T>, jest.Mock>> & {
+  [key: string]: jest.Mock;
+};
+
+function createMockRepo(): MockRepo {
+  return {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+    countBy: jest.fn(),
+    findOneByOrFail: jest.fn(),
+    remove: jest.fn(),
+    existsBy: jest.fn(),
+  };
+}
+
+describe('CompaniesService', () => {
+  let companiesRepo: MockRepo<Company>;
+  let jobAppsRepo: MockRepo<JobApplication>;
+  let service: CompaniesService;
+  const user: AuthUserDto = { userId: 'user-1', email: 'a@b.com' };
+
+  beforeEach(() => {
+    companiesRepo = createMockRepo();
+    jobAppsRepo = createMockRepo();
+    service = new CompaniesService(companiesRepo as any, jobAppsRepo as any);
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  it('creates a company without jobApplicationId', async () => {
+    const dto: CreateCompanyDto = { name: 'Acme' } as any;
+
+    (companiesRepo.create as jest.Mock).mockReturnValue({ ...dto });
+    (companiesRepo.save as jest.Mock).mockResolvedValue({ id: 'c1' });
+    (companiesRepo.findOne as jest.Mock).mockResolvedValue({
+      id: 'c1',
+      name: 'Acme',
+      jobApplications: [],
+    });
+
+    const res = await service.create(dto, user);
+
+    expect(companiesRepo.create).toHaveBeenCalledWith({ ...dto });
+    expect(companiesRepo.save).toHaveBeenCalled();
+    expect(res).toEqual({ id: 'c1', name: 'Acme', jobApplications: [] });
+    expect(jobAppsRepo.existsBy).not.toHaveBeenCalled();
+  });
+
+  it('throws when creating with jobApplicationId that does not belong to user', async () => {
+    const dto: CreateCompanyDto = { name: 'X', jobApplicationId: 'ja-1' } as any;
+
+    (jobAppsRepo.existsBy as jest.Mock).mockResolvedValue(false);
+
+    await expect(service.create(dto, user)).rejects.toThrow(NotFoundException);
+    expect(jobAppsRepo.existsBy).toHaveBeenCalledWith({
+      id: dto.jobApplicationId,
+      column: { board: { user: { id: user.userId } } },
+    });
+  });
+
+  it('findOne returns company when there are no job applications', async () => {
+    const company = { id: 'c1', name: 'C', jobApplications: [] };
+    (companiesRepo.findOne as jest.Mock).mockResolvedValue(company);
+
+    const res = await service.findOne('c1', user);
+
+    expect(companiesRepo.findOne).toHaveBeenCalledWith({
+      where: { id: 'c1' },
+      relations: { jobApplications: true },
+    });
+    expect(res).toBe(company);
+  });
+
+  it('findOne refetches when company has jobApplications and checks ownership', async () => {
+    const initial = { id: 'c2', name: 'C2', jobApplications: [{ id: 'ja' }] };
+    const filtered = { id: 'c2', name: 'C2', jobApplications: [{ id: 'ja' }] };
+
+    (companiesRepo.findOne as jest.Mock)
+      .mockResolvedValueOnce(initial)
+      .mockResolvedValueOnce(filtered);
+
+    const res = await service.findOne('c2', user);
+
+    expect(companiesRepo.findOne).toHaveBeenNthCalledWith(1, {
+      where: { id: 'c2' },
+      relations: { jobApplications: true },
+    });
+
+    expect(companiesRepo.findOne).toHaveBeenNthCalledWith(2, {
+      where: { id: 'c2', jobApplications: { column: { board: { user: { id: user.userId } } } } },
+      relations: { jobApplications: true },
+    });
+
+    expect(res).toBe(filtered);
+  });
+
+  it('findOne throws NotFoundException when company not found', async () => {
+    // service first fetch reads company.jobApplications; to reach the NotFoundException
+    // path we return a company with jobApplications (so it refetches) and then
+    // return null on the refetch so the NotFoundException is thrown.
+    (companiesRepo.findOne as jest.Mock)
+      .mockResolvedValueOnce({ id: 'x', jobApplications: [1] })
+      .mockResolvedValueOnce(null);
+
+    await expect(service.findOne('missing', user)).rejects.toThrow(NotFoundException);
+  });
+
+  it('update merges and saves then returns updated entity', async () => {
+    const existing = { id: 'c3', name: 'Old', jobApplications: [] } as any;
+    const dto: UpdateCompanyDto = { name: 'New' } as any;
+
+    (companiesRepo.findOne as jest.Mock)
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce({ id: 'c3', name: 'New', jobApplications: [] });
+    (companiesRepo.save as jest.Mock).mockResolvedValue({ id: 'c3', name: 'New' });
+
+    const res = await service.update('c3', dto, user);
+
+    expect(companiesRepo.save).toHaveBeenCalled();
+    expect(res).toEqual({ id: 'c3', name: 'New', jobApplications: [] });
+  });
+
+  it('remove removes the entity after verifying ownership', async () => {
+    const existing = { id: 'c4', name: 'ToRemove', jobApplications: [] } as any;
+    (companiesRepo.findOne as jest.Mock).mockResolvedValue(existing);
+    (companiesRepo.remove as jest.Mock).mockResolvedValue(existing);
+
+    const res = await service.remove('c4', user);
+
+    expect(companiesRepo.remove).toHaveBeenCalledWith(existing);
+    expect(res).toBe(existing);
+  });
+});

--- a/src/modules/contacts/contact-methods.service.ts
+++ b/src/modules/contacts/contact-methods.service.ts
@@ -6,9 +6,9 @@ import { ContactPhoneMapper } from './mappers/contact-phone.mapper';
 import { Contact } from './entities/contact.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ContactEmailDto } from './dtos/contact-method/contact-email.dto';
-import { ArgumentInvalidException } from 'src/exceptions/argument-invalid.exceptions';
+import { ArgumentInvalidException } from '../../exceptions/argument-invalid.exceptions';
 import { ContactPhoneDto } from './dtos/contact-method/contact-phone.dto';
-import { BadRequestException } from 'src/exceptions/bad-request.exception';
+import { BadRequestException } from '../../exceptions/bad-request.exception';
 import { CreateContactEmailDto } from './dtos/contact-method/create-contact-email.dto';
 import { CreateContactPhoneDto } from './dtos/contact-method/create-contact-phone.dto';
 

--- a/src/modules/documents/documents.service.spec.ts
+++ b/src/modules/documents/documents.service.spec.ts
@@ -1,0 +1,195 @@
+import { NotFoundException } from '@nestjs/common';
+import { DocumentsService } from './documents.service';
+import { CreateDocumentDto } from './dtos/create-document.dto';
+import { UpdateDocumentDto } from './dtos/update-document.dto';
+
+type MockRepo = Partial<Record<string, jest.Mock>> & { [key: string]: jest.Mock };
+
+function createMockRepo(): MockRepo {
+  return {
+    findOne: jest.fn(),
+    findOneBy: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    countBy: jest.fn(),
+    remove: jest.fn(),
+  };
+}
+
+describe('DocumentsService', () => {
+  let documentsRepo: MockRepo;
+  let usersRepo: MockRepo;
+  let boardsRepo: MockRepo;
+  let jobAppsRepo: MockRepo;
+  let appwriteUploadsService: { uploadFile: jest.Mock };
+  let service: DocumentsService;
+
+  beforeEach(() => {
+    documentsRepo = createMockRepo();
+    usersRepo = createMockRepo();
+    boardsRepo = createMockRepo();
+    jobAppsRepo = createMockRepo();
+
+    appwriteUploadsService = { uploadFile: jest.fn() };
+
+    service = new DocumentsService(
+      documentsRepo as any,
+      appwriteUploadsService as any,
+      usersRepo as any,
+      boardsRepo as any,
+      jobAppsRepo as any,
+    );
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  it('create stores uploaded file and returns saved document (no board)', async () => {
+    const file: any = { originalname: 'file.pdf', size: 1234 };
+    const dto: CreateDocumentDto = { title: 'T', category: 0 } as any;
+
+    (usersRepo.findOneBy as jest.Mock).mockResolvedValue({ id: 'u1' });
+    appwriteUploadsService.uploadFile.mockResolvedValue({ url: 'https://cdn/file.pdf' });
+    (documentsRepo.create as jest.Mock).mockReturnValue({});
+    (documentsRepo.save as jest.Mock).mockResolvedValue({ id: 'd1', url: 'https://cdn/file.pdf' });
+
+    const res = await service.create(file, dto, 'u1');
+
+    expect(usersRepo.findOneBy).toHaveBeenCalledWith({ id: 'u1' });
+    expect(appwriteUploadsService.uploadFile).toHaveBeenCalledWith(file);
+    expect(documentsRepo.save).toHaveBeenCalled();
+    expect(res).toHaveProperty('id', 'd1');
+  });
+
+  it('create handles boardId and attaches board', async () => {
+    const file: any = { originalname: 'file.docx', size: 10 };
+    const dto: any = { title: 'T', category: 0, boardId: 'b1' };
+
+    (usersRepo.findOneBy as jest.Mock).mockResolvedValue({ id: 'u1' });
+    appwriteUploadsService.uploadFile.mockResolvedValue({ url: 'https://cdn/file.docx' });
+    (boardsRepo.findOneBy as jest.Mock).mockResolvedValue({ id: 'b1' });
+    (documentsRepo.create as jest.Mock).mockReturnValue({});
+    (documentsRepo.save as jest.Mock).mockResolvedValue({ id: 'd2', board: { id: 'b1' } });
+
+    const res = await service.create(file, dto, 'u1');
+
+    expect(boardsRepo.findOneBy).toHaveBeenCalledWith({ id: 'b1' });
+    expect(res).toHaveProperty('id', 'd2');
+  });
+
+  it('findOneById returns document or throws NotFoundException', async () => {
+    (documentsRepo.findOne as jest.Mock).mockResolvedValue({ id: 'd1' });
+
+    const doc = await service.findOneById('d1', 'u1');
+    expect(doc).toEqual({ id: 'd1' });
+
+    (documentsRepo.findOne as jest.Mock).mockResolvedValue(null);
+    await expect(service.findOneById('x', 'u1')).rejects.toThrow(NotFoundException);
+  });
+
+  it('findAndPaginate returns items and total', async () => {
+    const query: any = {
+      sort: [{ by: 'createdAt', dir: 'desc' }],
+      page: 1,
+      take: 10,
+      filter: { title: 'x' },
+    };
+    const items = [{ id: 'd1' }];
+    (documentsRepo.find as jest.Mock).mockResolvedValue(items);
+    (documentsRepo.countBy as jest.Mock).mockResolvedValue(42);
+
+    const res = await service.findAndPaginate(query, 'u1');
+
+    expect(documentsRepo.find).toHaveBeenCalled();
+    expect(res).toMatchObject({ items, total: 42, page: 1, take: 10 });
+  });
+
+  it('attachDocumentToJobApplication attaches when both exist', async () => {
+    const doc = { id: 'd1', jobApplications: [] } as any;
+    (documentsRepo.findOne as jest.Mock).mockResolvedValue(doc);
+    (jobAppsRepo.findOneBy as jest.Mock).mockResolvedValue({ id: 'ja1' });
+    (documentsRepo.save as jest.Mock).mockResolvedValue({});
+
+    await service.attachDocumentToJobApplication('d1', 'ja1', 'u1');
+
+    expect(documentsRepo.findOne).toHaveBeenCalled();
+    expect(jobAppsRepo.findOneBy).toHaveBeenCalledWith({
+      id: 'ja1',
+      column: { board: { user: { id: 'u1' } } },
+    });
+    expect(documentsRepo.save).toHaveBeenCalledWith(doc);
+  });
+
+  it('attachDocumentToJobApplication throws when document or job application missing', async () => {
+    (documentsRepo.findOne as jest.Mock).mockResolvedValue(null);
+    await expect(service.attachDocumentToJobApplication('d1', 'ja1', 'u1')).rejects.toThrow(
+      NotFoundException,
+    );
+
+    (documentsRepo.findOne as jest.Mock).mockResolvedValue({ id: 'd1', jobApplications: [] });
+    (jobAppsRepo.findOneBy as jest.Mock).mockResolvedValue(null);
+    await expect(service.attachDocumentToJobApplication('d1', 'ja1', 'u1')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('detachDocumentFromJobApplication removes relation or throws', async () => {
+    (documentsRepo.findOne as jest.Mock).mockResolvedValue(null);
+    await expect(service.detachDocumentFromJobApplication('d1', 'ja1', 'u1')).rejects.toThrow(
+      NotFoundException,
+    );
+
+    const doc = { id: 'd1', jobApplications: [{ id: 'ja1' }] } as any;
+    (documentsRepo.findOne as jest.Mock).mockResolvedValue(doc);
+    (documentsRepo.save as jest.Mock).mockResolvedValue({});
+
+    await service.detachDocumentFromJobApplication('d1', 'ja1', 'u1');
+    expect(documentsRepo.save).toHaveBeenCalled();
+
+    const doc2 = { id: 'd1', jobApplications: [{ id: 'other' }] } as any;
+    (documentsRepo.findOne as jest.Mock).mockResolvedValue(doc2);
+    await expect(service.detachDocumentFromJobApplication('d1', 'ja1', 'u1')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('update updates fields and handles file upload', async () => {
+    const existing = { id: 'd1', url: 'old' } as any;
+    (documentsRepo.findOne as jest.Mock).mockResolvedValue(existing);
+    appwriteUploadsService.uploadFile.mockResolvedValue({ url: 'https://cdn/new' });
+    (documentsRepo.save as jest.Mock).mockResolvedValue({ id: 'd1', url: 'https://cdn/new' });
+
+    const file: any = { originalname: 'new.txt', size: undefined };
+
+    const res = await service.update('d1', { title: 'New' } as UpdateDocumentDto, 'u1', file);
+
+    expect(appwriteUploadsService.uploadFile).toHaveBeenCalledWith(file);
+    expect(documentsRepo.save).toHaveBeenCalled();
+    expect(res).toHaveProperty('id', 'd1');
+  });
+
+  it('update and delete throw when document not found', async () => {
+    (documentsRepo.findOne as jest.Mock).mockResolvedValue(null);
+    await expect(service.update('x', { title: 'X' } as any, 'u1')).rejects.toThrow(
+      NotFoundException,
+    );
+    await expect(service.delete('x', 'u1')).rejects.toThrow(NotFoundException);
+  });
+
+  it('delete removes document', async () => {
+    const existing = { id: 'd1' } as any;
+    (documentsRepo.findOne as jest.Mock).mockResolvedValue(existing);
+    (documentsRepo.remove as jest.Mock).mockResolvedValue(existing);
+
+    const res = await service.delete('d1', 'u1');
+    expect(documentsRepo.remove).toHaveBeenCalledWith(existing);
+    expect(res).toBe(existing);
+  });
+
+  it('getAllDocumentsPerBoard and getAllDocumentPerUser call repo find', () => {
+    service.getAllDocumentsPerBoard('b1', 'u1');
+    service.getAllDocumentPerUser('u1');
+
+    expect(documentsRepo.find).toHaveBeenCalled();
+  });
+});

--- a/src/modules/job-application-notes/job-application-notes.service.spec.ts
+++ b/src/modules/job-application-notes/job-application-notes.service.spec.ts
@@ -1,5 +1,12 @@
 import { JobApplicationNotesService } from './job-application-notes.service';
 import { JobApplicationNoteMapper } from './job-application-notes.mapper';
+import { Test, TestingModule } from '@nestjs/testing';
+import { JobApplicationNote } from './entities/job-application-note.entity';
+import { JobApplication } from '../job-applications/entities/job-application.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreateJobApplicationNoteDto } from './dtos/create-job-application-note.dto';
+import { UpdateJobApplicationNote } from './dtos/update-job-application-note.dto';
 
 type MockRepo = Partial<Record<string, jest.Mock>> & { [key: string]: jest.Mock };
 
@@ -19,117 +26,196 @@ function createMockRepo(): MockRepo {
 }
 
 describe('JobApplicationNotesService', () => {
-  let notesRepo: MockRepo;
-  let jobAppsRepo: MockRepo;
   let mapper: JobApplicationNoteMapper;
   let service: JobApplicationNotesService;
+  let notesRepository: Repository<JobApplicationNote>;
+  let jobApplicationRepository: Repository<JobApplication>;
 
-  beforeEach(() => {
-    notesRepo = createMockRepo();
-    jobAppsRepo = createMockRepo();
+  const validUserId = '8167a958-5d55-476a-8bd2-f5fcdb8e9c5b';
+  const validNote = {
+    id: '75e7509c-7406-41fc-9552-e4aa55a54a5a',
+    jobApplication: {
+      id: '7728dbbc-cfa9-471a-a9f7-49acc5455510',
+    },
+    content: '',
+    order: 0,
+  } as JobApplicationNote;
+
+  beforeEach(async () => {
+    const notesMock = createMockRepo();
+    const jobAPplicationMock = createMockRepo();
     mapper = new JobApplicationNoteMapper();
 
-    service = new JobApplicationNotesService(notesRepo as any, jobAppsRepo as any, mapper);
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JobApplicationNotesService,
+        { provide: getRepositoryToken(JobApplicationNote), useValue: notesMock },
+        { provide: getRepositoryToken(JobApplication), useValue: jobAPplicationMock },
+        { provide: JobApplicationNoteMapper, useValue: mapper },
+      ],
+    }).compile();
+
+    service = module.get<JobApplicationNotesService>(JobApplicationNotesService);
+    notesRepository = module.get<Repository<JobApplicationNote>>(
+      getRepositoryToken(JobApplicationNote),
+    );
+    jobApplicationRepository = module.get<Repository<JobApplication>>(
+      getRepositoryToken(JobApplication),
+    );
   });
 
   afterEach(() => jest.resetAllMocks());
 
-  it('create validates job application and returns dto', async () => {
-    const dto: any = { jobApplicationId: 'ja1', content: 'hello' };
-    (jobAppsRepo.existsBy as jest.Mock).mockResolvedValue(true);
-    (notesRepo.countBy as jest.Mock).mockResolvedValue(2);
-    (notesRepo.create as jest.Mock).mockReturnValue({ ...dto });
-    (notesRepo.save as jest.Mock).mockResolvedValue({ id: 'n1', content: 'hello', order: 2 });
+  describe('create', () => {
+    it('create validates job application and returns dto', async () => {
+      // Arrange
+      const dto: CreateJobApplicationNoteDto = {
+        jobApplicationId: validNote.jobApplication.id,
+        content: 'hello world',
+      };
+      jest.spyOn(jobApplicationRepository, 'existsBy').mockResolvedValue(true);
+      jest.spyOn(notesRepository, 'countBy').mockResolvedValue(2);
+      jest.spyOn(notesRepository, 'create').mockReturnValue(validNote);
+      jest.spyOn(notesRepository, 'save').mockResolvedValue({ ...validNote, content: dto.content });
 
-    const res = await service.create(dto, 'user-1');
+      // Act
+      const res = await service.create(dto, validUserId);
 
-    expect(jobAppsRepo.existsBy).toHaveBeenCalledWith({
-      id: 'ja1',
-      column: { board: { user: { id: 'user-1' } } },
+      // Assert
+      expect(jobApplicationRepository.existsBy).toHaveBeenCalledWith({
+        id: validNote.jobApplication.id,
+        column: { board: { user: { id: validUserId } } },
+      });
+      expect(notesRepository.countBy).toHaveBeenCalled();
+      expect(notesRepository.save).toHaveBeenCalled();
+      expect(res).toHaveProperty('id', validNote.id);
+      expect(res).toHaveProperty('content', dto.content);
     });
-    expect(notesRepo.countBy).toHaveBeenCalled();
-    expect(notesRepo.save).toHaveBeenCalled();
-    expect(res).toHaveProperty('id', 'n1');
-    expect(res).toHaveProperty('content', 'hello');
+
+    it('create throws when job application id missing', async () => {
+      // Arrange
+      const dto: CreateJobApplicationNoteDto = { jobApplicationId: null, content: 'x' };
+
+      // Act & Assert
+      await expect(service.create(dto, validUserId)).rejects.toThrow();
+    });
   });
 
-  it('create throws when job application id missing', async () => {
-    const dto: any = { jobApplicationId: null, content: 'x' };
+  describe('find', () => {
+    it('find returns mapped dtos', async () => {
+      // Arrange
+      const entities = [
+        validNote,
+        { id: 'd3b328c5-2973-46e4-8c6a-123b04922543', content: 'b', order: 1 },
+      ] as JobApplicationNote[];
+      jest.spyOn(jobApplicationRepository, 'existsBy').mockResolvedValue(true);
+      jest.spyOn(notesRepository, 'find').mockResolvedValue(entities);
 
-    await expect(service.create(dto, 'user-1')).rejects.toThrow();
+      // Act
+      const res = await service.find('ja1', validUserId);
+
+      // Assert
+      expect(jobApplicationRepository.existsBy).toHaveBeenCalled();
+      expect(res).toHaveLength(2);
+      expect(res[0]).toHaveProperty('id', validNote.id);
+    });
   });
 
-  it('find returns mapped dtos', async () => {
-    (jobAppsRepo.existsBy as jest.Mock).mockResolvedValue(true);
-    const entities = [
-      { id: 'n1', content: 'a', order: 0 },
-      { id: 'n2', content: 'b', order: 1 },
-    ];
-    (notesRepo.find as jest.Mock).mockResolvedValue(entities);
+  describe('update', () => {
+    it('update throws when entity not found', async () => {
+      // Arrange
+      const randomId = '12e2f567-1cd2-4847-b09e-d4bf6ef7e9df';
+      jest.spyOn(notesRepository, 'findOneBy').mockResolvedValue(null);
 
-    const res = await service.find('ja1', 'user-1');
+      // Act & Assert
+      await expect(
+        service.update(randomId, { content: 'x' } as UpdateJobApplicationNote, validUserId),
+      ).rejects.toThrow("JobApplicationNote doesn't exist.");
+    });
 
-    expect(jobAppsRepo.existsBy).toHaveBeenCalled();
-    expect(res).toHaveLength(2);
-    expect(res[0]).toHaveProperty('id', 'n1');
+    it('update saves and returns dto', async () => {
+      // Arrange
+      jest.spyOn(notesRepository, 'findOneBy').mockResolvedValue(validNote);
+      jest.spyOn(notesRepository, 'save').mockResolvedValue({ ...validNote, content: 'updated' });
+
+      // Act
+      const res = await service.update(
+        validNote.id,
+        { content: 'updated' } as UpdateJobApplicationNote,
+        validUserId,
+      );
+
+      // Assert
+      expect(notesRepository.save).toHaveBeenCalled();
+      expect(res).toHaveProperty('content', 'updated');
+    });
   });
 
-  it('update throws when entity not found', async () => {
-    (notesRepo.findOneBy as jest.Mock).mockResolvedValue(undefined);
+  describe('rearrange', () => {
+    it('rearrange validates ids and upserts', async () => {
+      // Arrange
+      const entities = [
+        { id: '75e7509c-7406-41fc-9552-e4aa55a54a5a' },
+        { id: 'd3b328c5-2973-46e4-8c6a-123b04922543' },
+        { id: '12e2f567-1cd2-4847-b09e-d4bf6ef7e9df' },
+      ] as JobApplicationNote[];
+      jest.spyOn(jobApplicationRepository, 'existsBy').mockResolvedValue(true);
+      jest.spyOn(notesRepository, 'findBy').mockResolvedValue(entities);
 
-    await expect(service.update('n1', { content: 'x' } as any, 'user-1')).rejects.toThrow(
-      "JobApplicationNote doesn't exist.",
-    );
+      // Act
+      await service.rearrange(
+        validNote.jobApplication.id,
+        [entities[2].id, entities[1].id, entities[0].id],
+        validUserId,
+      );
+
+      // Assert
+      expect(notesRepository.upsert).toHaveBeenCalled();
+    });
+
+    it('rearrange throws on duplicate ids', async () => {
+      // Arrange
+      const entities = [
+        { id: '75e7509c-7406-41fc-9552-e4aa55a54a5a' },
+        { id: 'd3b328c5-2973-46e4-8c6a-123b04922543' },
+      ] as JobApplicationNote[];
+      jest.spyOn(jobApplicationRepository, 'existsBy').mockResolvedValue(true);
+      jest.spyOn(notesRepository, 'findBy').mockResolvedValue(entities);
+
+      // Act & Assert
+      await expect(
+        service.rearrange(
+          validNote.jobApplication.id,
+          [entities[0].id, entities[0].id],
+          validUserId,
+        ),
+      ).rejects.toThrow('List has duplicated Id.');
+    });
   });
 
-  it('update saves and returns dto', async () => {
-    const entity = { id: 'n1', content: 'a', order: 0 } as any;
-    (notesRepo.findOneBy as jest.Mock).mockResolvedValue(entity);
-    (notesRepo.save as jest.Mock).mockResolvedValue({ ...entity, content: 'updated' });
+  describe('delete', () => {
+    it('delete throws when not found', async () => {
+      // Arrange
+      const randomId = 'a2a1638b-e35b-445a-894f-e46a059f50c5;';
+      jest.spyOn(notesRepository, 'findOne').mockResolvedValue(null);
 
-    const res = await service.update('n1', { content: 'updated' } as any, 'user-1');
+      // Act & Assert
+      await expect(service.delete(randomId, validUserId)).rejects.toThrow(
+        "JobApplicationNote doesn't exist.",
+      );
+    });
 
-    expect(notesRepo.save).toHaveBeenCalled();
-    expect(res).toHaveProperty('content', 'updated');
-  });
+    it('delete soft deletes and calls rearrangeAfterDelete', async () => {
+      // Arrange
+      jest.spyOn(notesRepository, 'findOne').mockResolvedValue(validNote);
+      jest.spyOn(notesRepository, 'find').mockResolvedValue([]);
 
-  it('rearrange validates ids and upserts', async () => {
-    (jobAppsRepo.existsBy as jest.Mock).mockResolvedValue(true);
-    const entities = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
-    (notesRepo.findBy as jest.Mock).mockResolvedValue(entities);
+      // Act
+      await service.delete(validNote.id, validUserId);
 
-    await service.rearrange('ja1', ['a', 'b', 'c'], 'user-1');
-
-    expect(notesRepo.upsert).toHaveBeenCalled();
-  });
-
-  it('rearrange throws on duplicate ids', async () => {
-    (jobAppsRepo.existsBy as jest.Mock).mockResolvedValue(true);
-    (notesRepo.findBy as jest.Mock).mockResolvedValue([{ id: 'a' }, { id: 'b' }]);
-
-    await expect(service.rearrange('ja1', ['a', 'a'], 'user-1')).rejects.toThrow(
-      'List has duplicated Id.',
-    );
-  });
-
-  it('delete throws when not found', async () => {
-    (notesRepo.findOne as jest.Mock).mockResolvedValue(undefined);
-
-    await expect(service.delete('n1', 'user-1')).rejects.toThrow(
-      "JobApplicationNote doesn't exist.",
-    );
-  });
-
-  it('delete soft deletes and calls rearrangeAfterDelete', async () => {
-    const note = { id: 'n1', jobApplication: { id: 'ja1' } } as any;
-    (notesRepo.findOne as jest.Mock).mockResolvedValue(note);
-    (notesRepo.softDelete as jest.Mock).mockResolvedValue({});
-    (notesRepo.find as jest.Mock).mockResolvedValue([]);
-    (notesRepo.upsert as jest.Mock).mockResolvedValue({});
-
-    await service.delete('n1', 'user-1');
-
-    expect(notesRepo.softDelete).toHaveBeenCalledWith(note.id);
-    expect(notesRepo.upsert).toHaveBeenCalled();
+      // Assert
+      expect(notesRepository.softDelete).toHaveBeenCalledWith(validNote.id);
+      expect(notesRepository.upsert).toHaveBeenCalled();
+    });
   });
 });

--- a/src/modules/job-application-notes/job-application-notes.service.spec.ts
+++ b/src/modules/job-application-notes/job-application-notes.service.spec.ts
@@ -1,0 +1,135 @@
+import { JobApplicationNotesService } from './job-application-notes.service';
+import { JobApplicationNoteMapper } from './job-application-notes.mapper';
+
+type MockRepo = Partial<Record<string, jest.Mock>> & { [key: string]: jest.Mock };
+
+function createMockRepo(): MockRepo {
+  return {
+    countBy: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOneBy: jest.fn(),
+    findBy: jest.fn(),
+    upsert: jest.fn(),
+    findOne: jest.fn(),
+    softDelete: jest.fn(),
+    existsBy: jest.fn(),
+  };
+}
+
+describe('JobApplicationNotesService', () => {
+  let notesRepo: MockRepo;
+  let jobAppsRepo: MockRepo;
+  let mapper: JobApplicationNoteMapper;
+  let service: JobApplicationNotesService;
+
+  beforeEach(() => {
+    notesRepo = createMockRepo();
+    jobAppsRepo = createMockRepo();
+    mapper = new JobApplicationNoteMapper();
+
+    service = new JobApplicationNotesService(notesRepo as any, jobAppsRepo as any, mapper);
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  it('create validates job application and returns dto', async () => {
+    const dto: any = { jobApplicationId: 'ja1', content: 'hello' };
+    (jobAppsRepo.existsBy as jest.Mock).mockResolvedValue(true);
+    (notesRepo.countBy as jest.Mock).mockResolvedValue(2);
+    (notesRepo.create as jest.Mock).mockReturnValue({ ...dto });
+    (notesRepo.save as jest.Mock).mockResolvedValue({ id: 'n1', content: 'hello', order: 2 });
+
+    const res = await service.create(dto, 'user-1');
+
+    expect(jobAppsRepo.existsBy).toHaveBeenCalledWith({
+      id: 'ja1',
+      column: { board: { user: { id: 'user-1' } } },
+    });
+    expect(notesRepo.countBy).toHaveBeenCalled();
+    expect(notesRepo.save).toHaveBeenCalled();
+    expect(res).toHaveProperty('id', 'n1');
+    expect(res).toHaveProperty('content', 'hello');
+  });
+
+  it('create throws when job application id missing', async () => {
+    const dto: any = { jobApplicationId: null, content: 'x' };
+
+    await expect(service.create(dto, 'user-1')).rejects.toThrow();
+  });
+
+  it('find returns mapped dtos', async () => {
+    (jobAppsRepo.existsBy as jest.Mock).mockResolvedValue(true);
+    const entities = [
+      { id: 'n1', content: 'a', order: 0 },
+      { id: 'n2', content: 'b', order: 1 },
+    ];
+    (notesRepo.find as jest.Mock).mockResolvedValue(entities);
+
+    const res = await service.find('ja1', 'user-1');
+
+    expect(jobAppsRepo.existsBy).toHaveBeenCalled();
+    expect(res).toHaveLength(2);
+    expect(res[0]).toHaveProperty('id', 'n1');
+  });
+
+  it('update throws when entity not found', async () => {
+    (notesRepo.findOneBy as jest.Mock).mockResolvedValue(undefined);
+
+    await expect(service.update('n1', { content: 'x' } as any, 'user-1')).rejects.toThrow(
+      "JobApplicationNote doesn't exist.",
+    );
+  });
+
+  it('update saves and returns dto', async () => {
+    const entity = { id: 'n1', content: 'a', order: 0 } as any;
+    (notesRepo.findOneBy as jest.Mock).mockResolvedValue(entity);
+    (notesRepo.save as jest.Mock).mockResolvedValue({ ...entity, content: 'updated' });
+
+    const res = await service.update('n1', { content: 'updated' } as any, 'user-1');
+
+    expect(notesRepo.save).toHaveBeenCalled();
+    expect(res).toHaveProperty('content', 'updated');
+  });
+
+  it('rearrange validates ids and upserts', async () => {
+    (jobAppsRepo.existsBy as jest.Mock).mockResolvedValue(true);
+    const entities = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+    (notesRepo.findBy as jest.Mock).mockResolvedValue(entities);
+
+    await service.rearrange('ja1', ['a', 'b', 'c'], 'user-1');
+
+    expect(notesRepo.upsert).toHaveBeenCalled();
+  });
+
+  it('rearrange throws on duplicate ids', async () => {
+    (jobAppsRepo.existsBy as jest.Mock).mockResolvedValue(true);
+    (notesRepo.findBy as jest.Mock).mockResolvedValue([{ id: 'a' }, { id: 'b' }]);
+
+    await expect(service.rearrange('ja1', ['a', 'a'], 'user-1')).rejects.toThrow(
+      'List has duplicated Id.',
+    );
+  });
+
+  it('delete throws when not found', async () => {
+    (notesRepo.findOne as jest.Mock).mockResolvedValue(undefined);
+
+    await expect(service.delete('n1', 'user-1')).rejects.toThrow(
+      "JobApplicationNote doesn't exist.",
+    );
+  });
+
+  it('delete soft deletes and calls rearrangeAfterDelete', async () => {
+    const note = { id: 'n1', jobApplication: { id: 'ja1' } } as any;
+    (notesRepo.findOne as jest.Mock).mockResolvedValue(note);
+    (notesRepo.softDelete as jest.Mock).mockResolvedValue({});
+    (notesRepo.find as jest.Mock).mockResolvedValue([]);
+    (notesRepo.upsert as jest.Mock).mockResolvedValue({});
+
+    await service.delete('n1', 'user-1');
+
+    expect(notesRepo.softDelete).toHaveBeenCalledWith(note.id);
+    expect(notesRepo.upsert).toHaveBeenCalled();
+  });
+});

--- a/src/modules/job-application-notes/job-application-notes.service.ts
+++ b/src/modules/job-application-notes/job-application-notes.service.ts
@@ -3,10 +3,10 @@ import { JobApplicationNote } from './entities/job-application-note.entity';
 import { JobApplication } from '../job-applications/entities/job-application.entity';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
-import { BadRequestException } from 'src/exceptions/bad-request.exception';
+import { BadRequestException } from '../../exceptions/bad-request.exception';
 import { JobApplicationNoteMapper } from './job-application-notes.mapper';
 import { CreateJobApplicationNoteDto } from './dtos/create-job-application-note.dto';
-import { ArgumentInvalidException } from 'src/exceptions/argument-invalid.exceptions';
+import { ArgumentInvalidException } from '../../exceptions/argument-invalid.exceptions';
 import { UpdateJobApplicationNote } from './dtos/update-job-application-note.dto';
 import { ExceptionMessages } from '../../exceptions/exception-messages';
 

--- a/src/modules/job-applications/dtos/job-application.dto.ts
+++ b/src/modules/job-applications/dtos/job-application.dto.ts
@@ -1,5 +1,5 @@
 import { BaseDto } from '../../../dtos/base.dto';
-import { JobApplicationNoteDto } from 'src/modules/job-application-notes/dtos/job-application-note.dto';
+import { JobApplicationNoteDto } from '../../job-application-notes/dtos/job-application-note.dto';
 import { BoardColumnDto } from '../../board-columns/dtos/board-column.dto';
 import { ContactDto } from '../../contacts/dtos/contact.dto';
 import { CompanyDto } from '../../companies/dtos/company.dto';

--- a/src/modules/job-applications/job-applications.service.spec.ts
+++ b/src/modules/job-applications/job-applications.service.spec.ts
@@ -6,6 +6,13 @@ import { BoardColumn } from '../board-columns/entities/board-column.entity';
 import { Contact } from '../contacts/entities/contact.entity';
 import { Company } from '../companies/entities/company.entity';
 import { JobApplicationNote } from '../job-application-notes/entities/job-application-note.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ContactsService } from '../contacts/contacts.service';
+import { JobApplicationNotesService } from '../job-application-notes/job-application-notes.service';
+import { CreateJobApplicationDto } from './dtos/create-job-application.dto';
+import { newGuid } from '../../utils/guid';
+import { UpdateJobApplicationDto } from './dtos/update-job-application.dto';
 
 type MockRepo<T = any> = Partial<Record<keyof Repository<T>, jest.Mock>> & {
   [key: string]: jest.Mock;
@@ -13,207 +20,306 @@ type MockRepo<T = any> = Partial<Record<keyof Repository<T>, jest.Mock>> & {
 
 function createMockRepo(): MockRepo {
   return {
-    existsBy: jest.fn(),
-    find: jest.fn(),
-    findOneOrFail: jest.fn(),
-    findOneByOrFail: jest.fn(),
-    findOneBy: jest.fn(),
+    countBy: jest.fn(),
     create: jest.fn(),
     save: jest.fn(),
+    find: jest.fn(),
+    findOneBy: jest.fn(),
+    findBy: jest.fn(),
+    upsert: jest.fn(),
+    findOne: jest.fn(),
+    findOneOrFail: jest.fn(),
+    findOneByOrFail: jest.fn(),
+    softDelete: jest.fn(),
+    existsBy: jest.fn(),
     delete: jest.fn(),
   };
 }
 
 describe('JobApplicationsService', () => {
-  let jobAppsRepo: MockRepo<JobApplication>;
-  let boardColumnsRepo: MockRepo<BoardColumn>;
-  let contactsRepo: MockRepo<Contact>;
-  let companiesRepo: MockRepo<Company>;
-  let jobAppNotesRepo: MockRepo<JobApplicationNote>;
-  let contactsService: { create: jest.Mock };
-  let jobAppNotesService: { create: jest.Mock };
   let service: JobApplicationsService;
+  let jobApplicationsRepository: Repository<JobApplication>;
+  let boardColumnsRepository: Repository<BoardColumn>;
+  let contactsRepository: Repository<Contact>;
+  let companiesRepository: Repository<Company>;
+  let jobApplicationNotesRepository: Repository<JobApplicationNote>;
+  let contactsService: ContactsService;
+  let jobApplicationNotesService: JobApplicationNotesService;
 
-  beforeEach(() => {
-    jobAppsRepo = createMockRepo();
-    boardColumnsRepo = createMockRepo();
-    contactsRepo = createMockRepo();
-    companiesRepo = createMockRepo();
-    jobAppNotesRepo = createMockRepo();
+  const validUserId = '8167a958-5d55-476a-8bd2-f5fcdb8e9c5b';
+  const validBoardId = 'b04d000-77a5-446e-bc84-9531bf312f9b';
+  const validColumnId = 'c010000-77a5-446e-bc84-9531bf312f9b';
+  const validCompanyId = '22849b46-06a9-4254-9965-fce8964ca40b';
+  const validJobApplication = {
+    id: '97658a08-3470-43fe-b415-a5d8b3aa57d5',
+    title: 'Test Job Application',
+    company: {
+      id: validCompanyId,
+    },
+    column: {
+      id: validColumnId,
+      board: {
+        id: validBoardId,
+      },
+    },
+  } as JobApplication;
 
-    contactsService = { create: jest.fn() };
-    jobAppNotesService = { create: jest.fn() };
+  beforeEach(async () => {
+    const jobApplicationMock = createMockRepo();
+    const boardColumnsMock = createMockRepo();
+    const contactsMock = createMockRepo();
+    const companiesMock = createMockRepo();
+    const jobApplicationNotesMock = createMockRepo();
+    const contactServiceMock = {
+      create: jest.fn(),
+    };
+    const jobApplicationNotesServiceMock = {};
 
-    service = new JobApplicationsService(
-      jobAppsRepo as any,
-      boardColumnsRepo as any,
-      contactsRepo as any,
-      contactsService as any,
-      companiesRepo as any,
-      jobAppNotesRepo as any,
-      jobAppNotesService as any,
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JobApplicationsService,
+        { provide: getRepositoryToken(JobApplication), useValue: jobApplicationMock },
+        { provide: getRepositoryToken(BoardColumn), useValue: boardColumnsMock },
+        { provide: getRepositoryToken(Contact), useValue: contactsMock },
+        { provide: getRepositoryToken(Company), useValue: companiesMock },
+        { provide: getRepositoryToken(JobApplicationNote), useValue: jobApplicationNotesMock },
+        { provide: ContactsService, useValue: contactServiceMock },
+        { provide: JobApplicationNotesService, useValue: jobApplicationNotesServiceMock },
+      ],
+    }).compile();
+
+    service = module.get<JobApplicationsService>(JobApplicationsService);
+    jobApplicationsRepository = module.get<Repository<JobApplication>>(
+      getRepositoryToken(JobApplication),
     );
+    boardColumnsRepository = module.get<Repository<BoardColumn>>(getRepositoryToken(BoardColumn));
+    contactsRepository = module.get<Repository<Contact>>(getRepositoryToken(Contact));
+    companiesRepository = module.get<Repository<Company>>(getRepositoryToken(Company));
+    jobApplicationNotesRepository = module.get<Repository<JobApplicationNote>>(
+      getRepositoryToken(JobApplicationNote),
+    );
+    contactsService = module.get<ContactsService>(ContactsService);
+    jobApplicationNotesService = module.get<JobApplicationNotesService>(JobApplicationNotesService);
   });
 
   afterEach(() => jest.resetAllMocks());
 
-  it('findBy throws BadRequestException when board column does not exist', async () => {
-    (boardColumnsRepo.existsBy as jest.Mock).mockResolvedValue(false);
+  describe('findBy', () => {
+    it('findBy throws BadRequestException when board column does not exist', async () => {
+      // Arrange
+      const randomId = 'a2a1638b-e35b-445a-894f-e46a059f50c5;';
+      jest.spyOn(boardColumnsRepository, 'existsBy').mockResolvedValue(false);
 
-    await expect(service.findBy('col-1', 'user-1')).rejects.toThrow(BadRequestException);
-    expect(boardColumnsRepo.existsBy).toHaveBeenCalledWith({
-      id: 'col-1',
-      board: { user: { id: 'user-1' } },
+      // Act & Assert
+      await expect(service.findBy(randomId, validUserId)).rejects.toThrow(BadRequestException);
+      expect(boardColumnsRepository.existsBy).toHaveBeenCalledWith({
+        id: randomId,
+        board: { user: { id: validUserId } },
+      });
+    });
+
+    it('findBy returns job applications when board column exists', async () => {
+      // Arrange
+      const jobs = [validJobApplication] as JobApplication[];
+      jest.spyOn(boardColumnsRepository, 'existsBy').mockResolvedValue(true);
+      jest.spyOn(jobApplicationsRepository, 'find').mockResolvedValue(jobs);
+
+      // Act
+      const res = await service.findBy(validColumnId, validUserId);
+
+      // Assert
+      expect(jobApplicationsRepository.find).toHaveBeenCalled();
+      expect(res).toBe(jobs);
+    });
+
+    it('findOneById delegates to repository findOneOrFail', async () => {
+      // Arrange
+      jest.spyOn(jobApplicationsRepository, 'findOneOrFail').mockResolvedValue(validJobApplication);
+
+      // Act
+      const res = await service.findOneById(validJobApplication.id, validUserId);
+
+      // Assert
+      expect(jobApplicationsRepository.findOneOrFail).toHaveBeenCalled();
+      expect(res).toBe(validJobApplication);
     });
   });
 
-  it('findBy returns job applications when board column exists', async () => {
-    (boardColumnsRepo.existsBy as jest.Mock).mockResolvedValue(true);
-    const jobs = [{ id: 'ja1' }, { id: 'ja2' }];
-    (jobAppsRepo.find as jest.Mock).mockResolvedValue(jobs);
+  describe('create', () => {
+    it('create saves entity and returns full entity (no contacts/notes)', async () => {
+      // Arrange
+      const dto: CreateJobApplicationDto = {
+        columnId: validColumnId,
+        title: validJobApplication.title,
+        companyId: validCompanyId,
+      };
+      jest.spyOn(boardColumnsRepository, 'existsBy').mockResolvedValue(true);
+      jest.spyOn(jobApplicationsRepository, 'create').mockReturnValue(validJobApplication);
+      jest.spyOn(jobApplicationsRepository, 'save').mockResolvedValue(validJobApplication);
+      jest.spyOn(jobApplicationsRepository, 'findOneOrFail').mockResolvedValue(validJobApplication);
 
-    const res = await service.findBy('col-1', 'user-1');
+      // Act
+      const res = await service.create(dto, validUserId);
 
-    expect(jobAppsRepo.find).toHaveBeenCalled();
-    expect(res).toBe(jobs);
-  });
-
-  it('findOneById delegates to repository findOneOrFail', async () => {
-    const ent = { id: 'ja1' } as any;
-    (jobAppsRepo.findOneOrFail as jest.Mock).mockResolvedValue(ent);
-
-    const res = await service.findOneById('ja1', 'user-1');
-
-    expect(jobAppsRepo.findOneOrFail).toHaveBeenCalled();
-    expect(res).toBe(ent);
-  });
-
-  it('create saves entity and returns full entity (no contacts/notes)', async () => {
-    const dto: any = { columnId: 'col-1', title: 'T' };
-    (boardColumnsRepo.existsBy as jest.Mock).mockResolvedValue(true);
-    (jobAppsRepo.create as jest.Mock).mockReturnValue({ ...dto, column: { id: 'col-1' } });
-    (jobAppsRepo.save as jest.Mock).mockResolvedValue({ id: 'ja-1' });
-    (jobAppsRepo.findOneOrFail as jest.Mock).mockResolvedValue({ id: 'ja-1', title: 'T' });
-
-    const res = await service.create(dto, 'user-1');
-
-    expect(boardColumnsRepo.existsBy).toHaveBeenCalled();
-    expect(jobAppsRepo.create).toHaveBeenCalled();
-    expect(jobAppsRepo.save).toHaveBeenCalledTimes(2);
-    expect(res).toEqual({ id: 'ja-1', title: 'T' });
-  });
-
-  it('create calls contactsService when contacts provided', async () => {
-    const dto: any = {
-      columnId: 'col-1',
-      title: 'T',
-      contacts: [{ firstName: 'A' }, { firstName: 'B' }],
-    };
-    (boardColumnsRepo.existsBy as jest.Mock).mockResolvedValue(true);
-    (jobAppsRepo.create as jest.Mock).mockReturnValue({ ...dto, column: { id: 'col-1' } });
-    (jobAppsRepo.save as jest.Mock).mockResolvedValue({ id: 'ja-2' });
-    contactsService.create.mockResolvedValueOnce({ id: 'c1' }).mockResolvedValueOnce({ id: 'c2' });
-    (jobAppsRepo.findOneOrFail as jest.Mock).mockResolvedValue({
-      id: 'ja-2',
-      title: 'T',
-      contacts: [{ id: 'c1' }, { id: 'c2' }],
+      // Assert
+      expect(boardColumnsRepository.existsBy).toHaveBeenCalled();
+      expect(jobApplicationsRepository.create).toHaveBeenCalled();
+      expect(jobApplicationsRepository.save).toHaveBeenCalledTimes(2);
+      expect(res).toEqual(validJobApplication);
     });
 
-    const res = await service.create(dto, 'user-1');
+    it('create calls contactsService when contacts provided', async () => {
+      // Arrange
+      const newContactId1 = newGuid();
+      const newContactId2 = newGuid();
+      const dto: CreateJobApplicationDto = {
+        columnId: validColumnId,
+        companyId: validCompanyId,
+        title: validJobApplication.title,
+        contacts: [
+          { firstName: 'A', lastName: 'A', boardId: validBoardId, companyIds: [validCompanyId] },
+          { firstName: 'B', lastName: 'B', boardId: validBoardId, companyIds: [validCompanyId] },
+        ],
+      };
+      jest.spyOn(boardColumnsRepository, 'existsBy').mockResolvedValue(true);
+      jest.spyOn(jobApplicationsRepository, 'create').mockReturnValue(validJobApplication);
+      jest.spyOn(jobApplicationsRepository, 'save').mockResolvedValue(validJobApplication);
+      jest
+        .spyOn(contactsService, 'create')
+        .mockResolvedValueOnce({ id: newContactId1 } as Contact)
+        .mockResolvedValueOnce({ id: newContactId2 } as Contact);
+      jest.spyOn(jobApplicationsRepository, 'findOneOrFail').mockResolvedValue({
+        id: validJobApplication.id,
+        title: validJobApplication.title,
+        contacts: [{ id: newContactId1 }, { id: newContactId2 }] as Contact[],
+      } as JobApplication);
 
-    expect(contactsService.create).toHaveBeenCalledTimes(2);
-    expect(jobAppsRepo.save).toHaveBeenCalledTimes(2);
-    expect(res).toEqual({ id: 'ja-2', title: 'T', contacts: [{ id: 'c1' }, { id: 'c2' }] });
+      // Act
+      const res = await service.create(dto, validUserId);
+
+      // Assert
+      expect(contactsService.create).toHaveBeenCalledTimes(2);
+      expect(jobApplicationsRepository.save).toHaveBeenCalledTimes(2);
+      expect(res).toEqual({
+        id: validJobApplication.id,
+        title: validJobApplication.title,
+        contacts: [{ id: newContactId1 }, { id: newContactId2 }],
+      });
+    });
   });
 
-  it('update throws when updating column to non-existing board column', async () => {
-    const existing = { id: 'ja1', column: { id: 'col-old' } } as any;
-    // first findOneById call used to check existence
-    jest
-      .spyOn(service, 'findOneById')
-      .mockResolvedValueOnce(existing)
-      .mockResolvedValueOnce(existing);
+  describe('update', () => {
+    it('update throws when updating column to non-existing board column', async () => {
+      // Arrange
+      const dto: UpdateJobApplicationDto = { columnId: newGuid() };
+      jest.spyOn(service, 'findOneById').mockResolvedValue(validJobApplication);
+      jest.spyOn(boardColumnsRepository, 'existsBy').mockResolvedValue(false);
 
-    (boardColumnsRepo.existsBy as jest.Mock).mockResolvedValue(false);
-
-    await expect(service.update('ja1', { columnId: 'col-new' } as any, 'user-1')).rejects.toThrow(
-      BadRequestException,
-    );
-  });
-
-  it('update throws when company id does not exist', async () => {
-    const existing = { id: 'ja1', column: { id: 'col-old' }, company: undefined } as any;
-    jest
-      .spyOn(service, 'findOneById')
-      .mockResolvedValueOnce(existing)
-      .mockResolvedValueOnce(existing);
-
-    (companiesRepo.findOneBy as jest.Mock).mockResolvedValue(undefined);
-
-    await expect(service.update('ja1', { companyId: 'comp-1' } as any, 'user-1')).rejects.toThrow(
-      BadRequestException,
-    );
-  });
-
-  it('delete removes company when job application deletion succeeds and company has no contacts', async () => {
-    const existing = { id: 'ja1', company: { id: 'comp-1', contacts: [] } } as any;
-    jest.spyOn(service, 'findOneById').mockResolvedValue(existing);
-
-    (jobAppsRepo.delete as jest.Mock).mockResolvedValue({});
-    (companiesRepo.delete as jest.Mock).mockResolvedValue({});
-
-    await service.delete('ja1', 'user-1');
-
-    expect(jobAppsRepo.delete).toHaveBeenCalledWith({ id: existing.id });
-    expect(companiesRepo.delete).toHaveBeenCalledWith({ id: existing.company.id });
-  });
-
-  it('delete swallows delete error and does not delete company', async () => {
-    const existing = { id: 'ja1', company: { id: 'comp-1', contacts: [] } } as any;
-    jest.spyOn(service, 'findOneById').mockResolvedValue(existing);
-
-    (jobAppsRepo.delete as jest.Mock).mockImplementation(() => {
-      throw new Error('boom');
+      // Act & Assert
+      await expect(service.update(validJobApplication.id, dto, validUserId)).rejects.toThrow(
+        BadRequestException,
+      );
     });
 
-    const res = await service.delete('ja1', 'user-1');
+    it('update throws when company id does not exist', async () => {
+      // Arrange
+      const dto: UpdateJobApplicationDto = { columnId: newGuid() };
+      jest
+        .spyOn(service, 'findOneById')
+        .mockResolvedValue({ ...structuredClone(validJobApplication), company: undefined });
+      jest.spyOn(companiesRepository, 'findOneBy').mockResolvedValue(null);
 
-    expect(jobAppsRepo.delete).toHaveBeenCalled();
-    expect(companiesRepo.delete).not.toHaveBeenCalled();
-    expect(res).toBeUndefined();
+      // Act & Assert
+      await expect(service.update(validJobApplication.id, dto, validUserId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
   });
 
-  it('attachContact saves when contact not already attached', async () => {
-    const jobApp = { id: 'ja1', contacts: [] } as any;
-    (jobAppsRepo.findOneByOrFail as jest.Mock).mockResolvedValue(jobApp);
-    (contactsRepo.findOneByOrFail as jest.Mock).mockResolvedValue({ id: 'c1' });
-    (jobAppsRepo.save as jest.Mock).mockResolvedValue({});
+  describe('delete', () => {
+    it('delete removes company when job application deletion succeeds and company has no contacts', async () => {
+      // Arrange
+      jest.spyOn(service, 'findOneById').mockResolvedValue(validJobApplication);
 
-    await service.attachContact('ja1', 'c1', 'user-1');
+      // Act
+      await service.delete(validJobApplication.id, validUserId);
 
-    expect(jobAppsRepo.save).toHaveBeenCalled();
+      // Assert
+      expect(jobApplicationsRepository.delete).toHaveBeenCalledWith({ id: validJobApplication.id });
+      expect(companiesRepository.delete).toHaveBeenCalledWith({
+        id: validJobApplication.company.id,
+      });
+    });
+
+    it('delete swallows delete error and does not delete company', async () => {
+      // Arrange
+      jest.spyOn(service, 'findOneById').mockResolvedValue(validJobApplication);
+      jest.spyOn(jobApplicationsRepository, 'delete').mockImplementation(() => {
+        throw new Error('error');
+      });
+
+      // Act
+      const res = await service.delete(validJobApplication.id, validUserId);
+
+      // Assert
+      expect(jobApplicationsRepository.delete).toHaveBeenCalled();
+      expect(companiesRepository.delete).not.toHaveBeenCalled();
+      expect(res).toBeUndefined();
+    });
   });
 
-  it('attachContact does not save when contact already attached', async () => {
-    const jobApp = { id: 'ja1', contacts: [{ id: 'c1' }] } as any;
-    (jobAppsRepo.findOneByOrFail as jest.Mock).mockResolvedValue(jobApp);
-    (contactsRepo.findOneByOrFail as jest.Mock).mockResolvedValue({ id: 'c1' });
+  describe('attachContact', () => {
+    it('attachContact saves when contact not already attached', async () => {
+      // Arrange
+      const contactEntity = { id: newGuid() } as Contact;
+      jest
+        .spyOn(jobApplicationsRepository, 'findOneByOrFail')
+        .mockResolvedValue({ ...structuredClone(validJobApplication), contacts: [] });
+      jest.spyOn(contactsRepository, 'findOneByOrFail').mockResolvedValue(contactEntity);
+      jest.spyOn(jobApplicationsRepository, 'save').mockResolvedValue({} as JobApplication);
 
-    await service.attachContact('ja1', 'c1', 'user-1');
+      // Act
+      await service.attachContact(validJobApplication.id, contactEntity.id, validUserId);
 
-    expect(jobAppsRepo.save).not.toHaveBeenCalled();
-  });
+      // Assert
+      expect(jobApplicationsRepository.save).toHaveBeenCalled();
+    });
 
-  it('attachCompany replaces existing company and deletes old one', async () => {
-    const jobApp = { id: 'ja1', company: { id: 'old' } } as any;
-    (jobAppsRepo.findOneByOrFail as jest.Mock).mockResolvedValue(jobApp);
-    (companiesRepo.findOneByOrFail as jest.Mock).mockResolvedValue({ id: 'new' });
-    (companiesRepo.delete as jest.Mock).mockResolvedValue({});
-    (jobAppsRepo.save as jest.Mock).mockResolvedValue({});
+    it('attachContact does not save when contact already attached', async () => {
+      // Arrange
+      const contactEntity = { id: newGuid() } as Contact;
+      jest
+        .spyOn(jobApplicationsRepository, 'findOneByOrFail')
+        .mockResolvedValue({ ...structuredClone(validJobApplication), contacts: [contactEntity] });
+      jest.spyOn(contactsRepository, 'findOneByOrFail').mockResolvedValue(contactEntity);
 
-    await service.attachCompany('ja1', 'new', 'user-1');
+      // Act
+      await service.attachContact(validJobApplication.id, contactEntity.id, validUserId);
 
-    expect(companiesRepo.delete).toHaveBeenCalledWith({ id: 'old' });
-    expect(jobAppsRepo.save).toHaveBeenCalled();
+      // Assert
+      expect(jobApplicationsRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('attachCompany replaces existing company and deletes old one', async () => {
+      // Arrange
+      const companyEntity = { id: newGuid() } as Company;
+      const newCompanyEntity = { id: newGuid() } as Company;
+      const jobApplicationEntity = {
+        ...structuredClone(validJobApplication),
+        company: companyEntity,
+      } as JobApplication;
+      jest
+        .spyOn(jobApplicationsRepository, 'findOneByOrFail')
+        .mockResolvedValue(jobApplicationEntity);
+      jest.spyOn(companiesRepository, 'findOneByOrFail').mockResolvedValue(newCompanyEntity);
+      jest.spyOn(jobApplicationsRepository, 'save').mockResolvedValue({} as JobApplication);
+
+      // Act
+      await service.attachCompany(jobApplicationEntity.id, newCompanyEntity.id, validUserId);
+
+      // Assert
+      expect(companiesRepository.delete).toHaveBeenCalledWith({ id: companyEntity.id });
+      expect(jobApplicationsRepository.save).toHaveBeenCalled();
+    });
   });
 });

--- a/src/modules/job-applications/job-applications.service.spec.ts
+++ b/src/modules/job-applications/job-applications.service.spec.ts
@@ -1,0 +1,219 @@
+import { BadRequestException } from '@nestjs/common';
+import { JobApplicationsService } from './job-applications.service';
+import { Repository } from 'typeorm';
+import { JobApplication } from './entities/job-application.entity';
+import { BoardColumn } from '../board-columns/entities/board-column.entity';
+import { Contact } from '../contacts/entities/contact.entity';
+import { Company } from '../companies/entities/company.entity';
+import { JobApplicationNote } from '../job-application-notes/entities/job-application-note.entity';
+
+type MockRepo<T = any> = Partial<Record<keyof Repository<T>, jest.Mock>> & {
+  [key: string]: jest.Mock;
+};
+
+function createMockRepo(): MockRepo {
+  return {
+    existsBy: jest.fn(),
+    find: jest.fn(),
+    findOneOrFail: jest.fn(),
+    findOneByOrFail: jest.fn(),
+    findOneBy: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    delete: jest.fn(),
+  };
+}
+
+describe('JobApplicationsService', () => {
+  let jobAppsRepo: MockRepo<JobApplication>;
+  let boardColumnsRepo: MockRepo<BoardColumn>;
+  let contactsRepo: MockRepo<Contact>;
+  let companiesRepo: MockRepo<Company>;
+  let jobAppNotesRepo: MockRepo<JobApplicationNote>;
+  let contactsService: { create: jest.Mock };
+  let jobAppNotesService: { create: jest.Mock };
+  let service: JobApplicationsService;
+
+  beforeEach(() => {
+    jobAppsRepo = createMockRepo();
+    boardColumnsRepo = createMockRepo();
+    contactsRepo = createMockRepo();
+    companiesRepo = createMockRepo();
+    jobAppNotesRepo = createMockRepo();
+
+    contactsService = { create: jest.fn() };
+    jobAppNotesService = { create: jest.fn() };
+
+    service = new JobApplicationsService(
+      jobAppsRepo as any,
+      boardColumnsRepo as any,
+      contactsRepo as any,
+      contactsService as any,
+      companiesRepo as any,
+      jobAppNotesRepo as any,
+      jobAppNotesService as any,
+    );
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  it('findBy throws BadRequestException when board column does not exist', async () => {
+    (boardColumnsRepo.existsBy as jest.Mock).mockResolvedValue(false);
+
+    await expect(service.findBy('col-1', 'user-1')).rejects.toThrow(BadRequestException);
+    expect(boardColumnsRepo.existsBy).toHaveBeenCalledWith({
+      id: 'col-1',
+      board: { user: { id: 'user-1' } },
+    });
+  });
+
+  it('findBy returns job applications when board column exists', async () => {
+    (boardColumnsRepo.existsBy as jest.Mock).mockResolvedValue(true);
+    const jobs = [{ id: 'ja1' }, { id: 'ja2' }];
+    (jobAppsRepo.find as jest.Mock).mockResolvedValue(jobs);
+
+    const res = await service.findBy('col-1', 'user-1');
+
+    expect(jobAppsRepo.find).toHaveBeenCalled();
+    expect(res).toBe(jobs);
+  });
+
+  it('findOneById delegates to repository findOneOrFail', async () => {
+    const ent = { id: 'ja1' } as any;
+    (jobAppsRepo.findOneOrFail as jest.Mock).mockResolvedValue(ent);
+
+    const res = await service.findOneById('ja1', 'user-1');
+
+    expect(jobAppsRepo.findOneOrFail).toHaveBeenCalled();
+    expect(res).toBe(ent);
+  });
+
+  it('create saves entity and returns full entity (no contacts/notes)', async () => {
+    const dto: any = { columnId: 'col-1', title: 'T' };
+    (boardColumnsRepo.existsBy as jest.Mock).mockResolvedValue(true);
+    (jobAppsRepo.create as jest.Mock).mockReturnValue({ ...dto, column: { id: 'col-1' } });
+    (jobAppsRepo.save as jest.Mock).mockResolvedValue({ id: 'ja-1' });
+    (jobAppsRepo.findOneOrFail as jest.Mock).mockResolvedValue({ id: 'ja-1', title: 'T' });
+
+    const res = await service.create(dto, 'user-1');
+
+    expect(boardColumnsRepo.existsBy).toHaveBeenCalled();
+    expect(jobAppsRepo.create).toHaveBeenCalled();
+    expect(jobAppsRepo.save).toHaveBeenCalledTimes(2);
+    expect(res).toEqual({ id: 'ja-1', title: 'T' });
+  });
+
+  it('create calls contactsService when contacts provided', async () => {
+    const dto: any = {
+      columnId: 'col-1',
+      title: 'T',
+      contacts: [{ firstName: 'A' }, { firstName: 'B' }],
+    };
+    (boardColumnsRepo.existsBy as jest.Mock).mockResolvedValue(true);
+    (jobAppsRepo.create as jest.Mock).mockReturnValue({ ...dto, column: { id: 'col-1' } });
+    (jobAppsRepo.save as jest.Mock).mockResolvedValue({ id: 'ja-2' });
+    contactsService.create.mockResolvedValueOnce({ id: 'c1' }).mockResolvedValueOnce({ id: 'c2' });
+    (jobAppsRepo.findOneOrFail as jest.Mock).mockResolvedValue({
+      id: 'ja-2',
+      title: 'T',
+      contacts: [{ id: 'c1' }, { id: 'c2' }],
+    });
+
+    const res = await service.create(dto, 'user-1');
+
+    expect(contactsService.create).toHaveBeenCalledTimes(2);
+    expect(jobAppsRepo.save).toHaveBeenCalledTimes(2);
+    expect(res).toEqual({ id: 'ja-2', title: 'T', contacts: [{ id: 'c1' }, { id: 'c2' }] });
+  });
+
+  it('update throws when updating column to non-existing board column', async () => {
+    const existing = { id: 'ja1', column: { id: 'col-old' } } as any;
+    // first findOneById call used to check existence
+    jest
+      .spyOn(service, 'findOneById')
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce(existing);
+
+    (boardColumnsRepo.existsBy as jest.Mock).mockResolvedValue(false);
+
+    await expect(service.update('ja1', { columnId: 'col-new' } as any, 'user-1')).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('update throws when company id does not exist', async () => {
+    const existing = { id: 'ja1', column: { id: 'col-old' }, company: undefined } as any;
+    jest
+      .spyOn(service, 'findOneById')
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce(existing);
+
+    (companiesRepo.findOneBy as jest.Mock).mockResolvedValue(undefined);
+
+    await expect(service.update('ja1', { companyId: 'comp-1' } as any, 'user-1')).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('delete removes company when job application deletion succeeds and company has no contacts', async () => {
+    const existing = { id: 'ja1', company: { id: 'comp-1', contacts: [] } } as any;
+    jest.spyOn(service, 'findOneById').mockResolvedValue(existing);
+
+    (jobAppsRepo.delete as jest.Mock).mockResolvedValue({});
+    (companiesRepo.delete as jest.Mock).mockResolvedValue({});
+
+    await service.delete('ja1', 'user-1');
+
+    expect(jobAppsRepo.delete).toHaveBeenCalledWith({ id: existing.id });
+    expect(companiesRepo.delete).toHaveBeenCalledWith({ id: existing.company.id });
+  });
+
+  it('delete swallows delete error and does not delete company', async () => {
+    const existing = { id: 'ja1', company: { id: 'comp-1', contacts: [] } } as any;
+    jest.spyOn(service, 'findOneById').mockResolvedValue(existing);
+
+    (jobAppsRepo.delete as jest.Mock).mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    const res = await service.delete('ja1', 'user-1');
+
+    expect(jobAppsRepo.delete).toHaveBeenCalled();
+    expect(companiesRepo.delete).not.toHaveBeenCalled();
+    expect(res).toBeUndefined();
+  });
+
+  it('attachContact saves when contact not already attached', async () => {
+    const jobApp = { id: 'ja1', contacts: [] } as any;
+    (jobAppsRepo.findOneByOrFail as jest.Mock).mockResolvedValue(jobApp);
+    (contactsRepo.findOneByOrFail as jest.Mock).mockResolvedValue({ id: 'c1' });
+    (jobAppsRepo.save as jest.Mock).mockResolvedValue({});
+
+    await service.attachContact('ja1', 'c1', 'user-1');
+
+    expect(jobAppsRepo.save).toHaveBeenCalled();
+  });
+
+  it('attachContact does not save when contact already attached', async () => {
+    const jobApp = { id: 'ja1', contacts: [{ id: 'c1' }] } as any;
+    (jobAppsRepo.findOneByOrFail as jest.Mock).mockResolvedValue(jobApp);
+    (contactsRepo.findOneByOrFail as jest.Mock).mockResolvedValue({ id: 'c1' });
+
+    await service.attachContact('ja1', 'c1', 'user-1');
+
+    expect(jobAppsRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('attachCompany replaces existing company and deletes old one', async () => {
+    const jobApp = { id: 'ja1', company: { id: 'old' } } as any;
+    (jobAppsRepo.findOneByOrFail as jest.Mock).mockResolvedValue(jobApp);
+    (companiesRepo.findOneByOrFail as jest.Mock).mockResolvedValue({ id: 'new' });
+    (companiesRepo.delete as jest.Mock).mockResolvedValue({});
+    (jobAppsRepo.save as jest.Mock).mockResolvedValue({});
+
+    await service.attachCompany('ja1', 'new', 'user-1');
+
+    expect(companiesRepo.delete).toHaveBeenCalledWith({ id: 'old' });
+    expect(jobAppsRepo.save).toHaveBeenCalled();
+  });
+});

--- a/src/modules/job-applications/job-applications.service.ts
+++ b/src/modules/job-applications/job-applications.service.ts
@@ -101,9 +101,6 @@ export class JobApplicationsService {
   }
 
   async update(id: string, dto: UpdateJobApplicationDto, userId: string): Promise<JobApplication> {
-    // Checks whether jobApplication exists for the current user
-    await this.findOneById(id, userId);
-
     const jobApplication = await this.findOneById(id, userId);
 
     // Updates the column_id field

--- a/src/modules/notification/notification-scheduler.service.spec.ts
+++ b/src/modules/notification/notification-scheduler.service.spec.ts
@@ -1,0 +1,109 @@
+import { NotificationSchedulerService } from './notification-scheduler.service';
+import { ReportNotificationEnum } from './enums/report-notification.enum';
+import { JobApplicationStatus } from '../job-applications/job-application-status.enum';
+
+describe('NotificationSchedulerService', () => {
+  let service: NotificationSchedulerService;
+  let repo: any;
+  let emailSender: any;
+  let configService: any;
+
+  beforeEach(() => {
+    repo = {
+      find: jest.fn(),
+      save: jest.fn(),
+      findBy: jest.fn(),
+    };
+    emailSender = {
+      sendEmail: jest.fn().mockResolvedValue(undefined),
+    };
+    configService = { get: jest.fn().mockReturnValue('http://frontend/') };
+
+    service = new NotificationSchedulerService(
+      configService as any,
+      emailSender as any,
+      repo as any,
+    );
+  });
+
+  it('calls sendEmail with correct subject and updates scheduledTime', async () => {
+    const notification = {
+      id: 'n1',
+      user: {
+        id: 'u1',
+        email: 'user@example.com',
+        firstName: 'John',
+        board: [
+          {
+            id: 'b1',
+            isArchived: false,
+          },
+        ],
+      },
+      time: '09:00',
+      type: ReportNotificationEnum.DAILY,
+      timezoneOffset: 0,
+      scheduledTime: new Date('2025-01-01T09:00:00Z'),
+    } as any;
+
+    repo.find.mockResolvedValue([notification]);
+
+    // Make prepareDataForReport truthy so email is sent
+    jest.spyOn(service as any, 'prepareDataForReport').mockReturnValue({
+      [JobApplicationStatus.JobCreated]: [],
+    });
+    jest.spyOn(service as any, 'generateJobsHtmlPage').mockReturnValue('<html></html>');
+    const next = new Date('2025-01-02T09:00:00Z');
+    jest.spyOn(service as any, 'calculateNextNotificationTime').mockReturnValue(next);
+
+    await service.sendScheduledNotification();
+
+    expect(emailSender.sendEmail).toHaveBeenCalledTimes(1);
+    // Do not validate email parameter or the html content
+    expect(emailSender.sendEmail).toHaveBeenCalledWith(
+      expect.anything(),
+      'Your Job Tracker Daily Report',
+      expect.any(String),
+    );
+
+    expect((service as any).calculateNextNotificationTime).toHaveBeenCalledWith(notification);
+    expect(repo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'n1',
+        scheduledTime: next,
+      }),
+    );
+  });
+
+  it('skips archived boards and does not call sendEmail', async () => {
+    const notification = {
+      id: 'n2',
+      user: {
+        id: 'u2',
+        email: 'arch@example.com',
+        firstName: 'Jane',
+        board: [
+          {
+            id: 'b2',
+            isArchived: true,
+          },
+        ],
+      },
+      time: '09:00',
+      type: ReportNotificationEnum.DAILY,
+      timezoneOffset: 0,
+      scheduledTime: new Date('2025-01-01T09:00:00Z'),
+    } as any;
+
+    repo.find.mockResolvedValue([notification]);
+    jest.spyOn(service as any, 'prepareDataForReport').mockReturnValue({});
+    jest.spyOn(service as any, 'generateJobsHtmlPage').mockReturnValue('<html></html>');
+    jest.spyOn(service as any, 'calculateNextNotificationTime').mockReturnValue(new Date());
+
+    await service.sendScheduledNotification();
+
+    expect(emailSender.sendEmail).not.toHaveBeenCalled();
+    // Still should reschedule and save
+    expect(repo.save).toHaveBeenCalled();
+  });
+});

--- a/src/modules/notification/notification-scheduler.service.spec.ts
+++ b/src/modules/notification/notification-scheduler.service.spec.ts
@@ -1,109 +1,146 @@
 import { NotificationSchedulerService } from './notification-scheduler.service';
 import { ReportNotificationEnum } from './enums/report-notification.enum';
 import { JobApplicationStatus } from '../job-applications/job-application-status.enum';
+import { NotificationSchedule } from './entities/notification-schedule.entity';
+import { BoardColumn } from '../board-columns/entities/board-column.entity';
+import { JobApplication } from '../job-applications/entities/job-application.entity';
+import { Company } from '../companies/entities/company.entity';
+import { ConfigService } from '@nestjs/config';
+import { EmailSenderService } from '../email-sender/email-sender.service';
+import { Repository } from 'typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
 
 describe('NotificationSchedulerService', () => {
   let service: NotificationSchedulerService;
-  let repo: any;
-  let emailSender: any;
-  let configService: any;
+  let repository: Repository<NotificationSchedule>;
+  let emailSender: EmailSenderService;
 
-  beforeEach(() => {
-    repo = {
-      find: jest.fn(),
-      save: jest.fn(),
-      findBy: jest.fn(),
-    };
-    emailSender = {
+  const validNotification = {
+    id: '52d49f16-4981-4f43-ab4e-3281f732cdd6',
+    user: {
+      id: '8167a958-5d55-476a-8bd2-f5fcdb8e9c5b',
+      email: 'user@example.com',
+      firstName: 'John',
+      board: [
+        {
+          id: '9f62c332-6b21-495e-be44-ff5c8df0d5c1',
+          isArchived: false,
+          columns: [
+            {
+              id: '39d7528f-ebaf-4bff-9586-5963740534d1',
+              name: 'Applied',
+              jobApplications: [
+                {
+                  id: '7728dbbc-cfa9-471a-a9f7-49acc5455510',
+                  status: JobApplicationStatus.Deadline,
+                  deadline: '2024-12-31T09:00:00Z', // a day before `validNotification.scheduledTime`
+                  title: 'Test Job Title',
+                  company: { name: 'Test Company Name' } as Company,
+                  salary: '€1000',
+                  column: { name: 'Applied' } as BoardColumn,
+                } as JobApplication,
+              ],
+            } as BoardColumn,
+          ],
+        },
+      ],
+    },
+    time: '09:00',
+    type: ReportNotificationEnum.DAILY,
+    timezoneOffset: 0,
+    scheduledTime: new Date('2025-01-01T09:00:00Z'),
+  } as NotificationSchedule;
+
+  beforeEach(async () => {
+    const repositoryMock = { find: jest.fn(), save: jest.fn(), findBy: jest.fn() };
+    const emailSenderMock = {
       sendEmail: jest.fn().mockResolvedValue(undefined),
     };
-    configService = { get: jest.fn().mockReturnValue('http://frontend/') };
+    const configServiceMock = { get: jest.fn().mockReturnValue('http://frontend/') };
 
-    service = new NotificationSchedulerService(
-      configService as any,
-      emailSender as any,
-      repo as any,
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationSchedulerService,
+        { provide: getRepositoryToken(NotificationSchedule), useValue: repositoryMock },
+        { provide: EmailSenderService, useValue: emailSenderMock },
+        { provide: ConfigService, useValue: configServiceMock },
+      ],
+    }).compile();
+    service = module.get<NotificationSchedulerService>(NotificationSchedulerService);
+    repository = module.get<Repository<NotificationSchedule>>(
+      getRepositoryToken(NotificationSchedule),
     );
+    emailSender = module.get<EmailSenderService>(EmailSenderService);
   });
 
-  it('calls sendEmail with correct subject and updates scheduledTime', async () => {
-    const notification = {
-      id: 'n1',
-      user: {
-        id: 'u1',
-        email: 'user@example.com',
-        firstName: 'John',
-        board: [
-          {
-            id: 'b1',
-            isArchived: false,
-          },
-        ],
-      },
-      time: '09:00',
-      type: ReportNotificationEnum.DAILY,
-      timezoneOffset: 0,
-      scheduledTime: new Date('2025-01-01T09:00:00Z'),
-    } as any;
+  describe('sendScheduledNotification', () => {
+    it('calls sendEmail with correct list of JobApplication and updates scheduledTime', async () => {
+      // Arrange
+      const next = new Date('2025-01-02T09:00:00Z');
+      jest.spyOn(repository, 'find').mockResolvedValue([validNotification]);
+      jest.spyOn(service, 'generateJobsHtmlPage').mockReturnValue('<html></html>');
+      jest.spyOn(service, 'calculateNextNotificationTime').mockReturnValue(next);
 
-    repo.find.mockResolvedValue([notification]);
+      // Act
+      await service.sendScheduledNotification();
 
-    // Make prepareDataForReport truthy so email is sent
-    jest.spyOn(service as any, 'prepareDataForReport').mockReturnValue({
-      [JobApplicationStatus.JobCreated]: [],
+      // Assert
+      expect(emailSender.sendEmail).toHaveBeenCalledTimes(1);
+      expect(emailSender.sendEmail).toHaveBeenCalledWith(
+        validNotification.user.email,
+        'Your Job Tracker Daily Report',
+        expect.any(String),
+      );
+      expect((service as any).calculateNextNotificationTime).toHaveBeenCalledWith(
+        validNotification,
+      );
+      expect((service as any).generateJobsHtmlPage).toHaveBeenCalledWith(
+        {
+          [JobApplicationStatus.JobCreated]: [],
+          [JobApplicationStatus.Deadline]: [
+            validNotification.user.board[0].columns[0].jobApplications[0],
+          ],
+          [JobApplicationStatus.Applied]: [],
+          [JobApplicationStatus.Interview]: [],
+          [JobApplicationStatus.OfferReceived]: [],
+          [JobApplicationStatus.JobMoved]: [],
+        } as Record<JobApplicationStatus, Array<JobApplication>>,
+        validNotification.user.board[0].id,
+        validNotification.user.firstName,
+        9,
+        validNotification.type,
+      );
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: validNotification.id,
+          scheduledTime: next,
+        }),
+      );
     });
-    jest.spyOn(service as any, 'generateJobsHtmlPage').mockReturnValue('<html></html>');
-    const next = new Date('2025-01-02T09:00:00Z');
-    jest.spyOn(service as any, 'calculateNextNotificationTime').mockReturnValue(next);
 
-    await service.sendScheduledNotification();
+    it('skips archived boards and does not call sendEmail', async () => {
+      // Arrange
+      const notificationWithArchivedBoard = structuredClone(validNotification);
+      notificationWithArchivedBoard.user.board[0].isArchived = true;
 
-    expect(emailSender.sendEmail).toHaveBeenCalledTimes(1);
-    // Do not validate email parameter or the html content
-    expect(emailSender.sendEmail).toHaveBeenCalledWith(
-      expect.anything(),
-      'Your Job Tracker Daily Report',
-      expect.any(String),
-    );
+      const next = new Date('2025-01-02T09:00:00Z');
+      jest.spyOn(repository, 'find').mockResolvedValue([notificationWithArchivedBoard]);
+      jest.spyOn(service, 'generateJobsHtmlPage').mockReturnValue('<html></html>');
+      jest.spyOn(service, 'calculateNextNotificationTime').mockReturnValue(next);
 
-    expect((service as any).calculateNextNotificationTime).toHaveBeenCalledWith(notification);
-    expect(repo.save).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'n1',
-        scheduledTime: next,
-      }),
-    );
-  });
+      // Act
+      await service.sendScheduledNotification();
 
-  it('skips archived boards and does not call sendEmail', async () => {
-    const notification = {
-      id: 'n2',
-      user: {
-        id: 'u2',
-        email: 'arch@example.com',
-        firstName: 'Jane',
-        board: [
-          {
-            id: 'b2',
-            isArchived: true,
-          },
-        ],
-      },
-      time: '09:00',
-      type: ReportNotificationEnum.DAILY,
-      timezoneOffset: 0,
-      scheduledTime: new Date('2025-01-01T09:00:00Z'),
-    } as any;
-
-    repo.find.mockResolvedValue([notification]);
-    jest.spyOn(service as any, 'prepareDataForReport').mockReturnValue({});
-    jest.spyOn(service as any, 'generateJobsHtmlPage').mockReturnValue('<html></html>');
-    jest.spyOn(service as any, 'calculateNextNotificationTime').mockReturnValue(new Date());
-
-    await service.sendScheduledNotification();
-
-    expect(emailSender.sendEmail).not.toHaveBeenCalled();
-    // Still should reschedule and save
-    expect(repo.save).toHaveBeenCalled();
+      // Assert
+      expect(emailSender.sendEmail).not.toHaveBeenCalled();
+      // Still should reschedule and save
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: notificationWithArchivedBoard.id,
+          scheduledTime: next,
+        }),
+      );
+    });
   });
 });

--- a/src/modules/notification/notification-scheduler.service.spec.ts
+++ b/src/modules/notification/notification-scheduler.service.spec.ts
@@ -155,10 +155,11 @@ describe('NotificationSchedulerService', () => {
       dayAgo.setDate(dayAgo.getDate() - 1);
       const tomorrow = new Date();
       tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
-      tomorrow.setUTCHours(9, 0, 0, 0);
+      tomorrow.setUTCHours(0, 0, 0, 0);
 
       const toBeRescheduled = structuredClone(validNotification);
       toBeRescheduled.scheduledTime = dayAgo;
+      toBeRescheduled.time = '00:00';
       jest.spyOn(repository, 'findBy').mockResolvedValue([toBeRescheduled]);
 
       // Act

--- a/src/modules/notification/notification-scheduler.service.spec.ts
+++ b/src/modules/notification/notification-scheduler.service.spec.ts
@@ -74,6 +74,10 @@ describe('NotificationSchedulerService', () => {
     emailSender = module.get<EmailSenderService>(EmailSenderService);
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe('sendScheduledNotification', () => {
     it('calls sendEmail with correct list of JobApplication and updates scheduledTime', async () => {
       // Arrange

--- a/src/modules/notification/notification-scheduler.service.spec.ts
+++ b/src/modules/notification/notification-scheduler.service.spec.ts
@@ -143,4 +143,30 @@ describe('NotificationSchedulerService', () => {
       );
     });
   });
+
+  describe('rescheduleExpiredNotifications', () => {
+    it('reschedules notifications with past scheduledTime', async () => {
+      // Arrange
+      const dayAgo = new Date();
+      dayAgo.setDate(dayAgo.getDate() - 1);
+      const tomorrow = new Date();
+      tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+      tomorrow.setUTCHours(9, 0, 0, 0);
+
+      const toBeRescheduled = structuredClone(validNotification);
+      toBeRescheduled.scheduledTime = dayAgo;
+      jest.spyOn(repository, 'findBy').mockResolvedValue([toBeRescheduled]);
+
+      // Act
+      await service.rescheduleExpiredNotifications();
+
+      // Assert
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: toBeRescheduled.id,
+          scheduledTime: tomorrow,
+        }),
+      );
+    });
+  });
 });

--- a/src/modules/notification/notification.service.spec.ts
+++ b/src/modules/notification/notification.service.spec.ts
@@ -3,134 +3,220 @@ import { NotificationService } from './notification.service';
 import { ReportNotificationEnum } from './enums/report-notification.enum';
 import { CreateDailyNotification } from './dtos/create-daily-notification.dto';
 import { CreateWeeklyNotification } from './dtos/create-weekly-notification.dto';
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationSchedule } from './entities/notification-schedule.entity';
+import { NotificationSchedulerService } from './notification-scheduler.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DayOfWeekEnum } from './enums/day-of-week.enum';
 
 describe('NotificationService', () => {
   let service: NotificationService;
-  let repo: any;
-  let scheduler: any;
+  let repository: Repository<NotificationSchedule>;
+  let scheduler: NotificationSchedulerService;
 
-  beforeEach(() => {
-    repo = {
+  const validDailyNotification = {
+    id: '52d49f16-4981-4f43-ab4e-3281f732cdd6',
+    user: {
+      id: '8167a958-5d55-476a-8bd2-f5fcdb8e9c5b',
+    },
+    time: '09:00',
+    type: ReportNotificationEnum.DAILY,
+    timezoneOffset: 0,
+    scheduledTime: new Date('2025-01-01T09:00:00Z'),
+  } as NotificationSchedule;
+
+  const validWeeklyNotification = {
+    id: '52d49f16-4981-4f43-ab4e-3281f732cdd6',
+    user: {
+      id: '8167a958-5d55-476a-8bd2-f5fcdb8e9c5b',
+    },
+    time: '10:00',
+    dayOfWeek: DayOfWeekEnum.MONDAY,
+    type: ReportNotificationEnum.WEEKLY,
+    timezoneOffset: -60,
+    scheduledTime: new Date('2025-01-01T10:00:00Z'),
+  } as NotificationSchedule;
+
+  beforeEach(async () => {
+    const repositoryMock = {
       findBy: jest.fn(),
       findOne: jest.fn(),
       create: jest.fn(),
       save: jest.fn(),
       delete: jest.fn(),
     };
-    scheduler = {
+    const schedulerMock = {
       calculateNextNotificationTime: jest.fn().mockReturnValue(new Date('2025-01-01T00:00:00Z')),
     };
-    service = new NotificationService(repo as any, scheduler as any);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationService,
+        { provide: getRepositoryToken(NotificationSchedule), useValue: repositoryMock },
+        { provide: NotificationSchedulerService, useValue: schedulerMock },
+      ],
+    }).compile();
+
+    service = module.get<NotificationService>(NotificationService);
+    repository = module.get(getRepositoryToken(NotificationSchedule));
+    scheduler = module.get<NotificationSchedulerService>(NotificationSchedulerService);
   });
 
-  it('creates daily notification and calls scheduler with correct entity', async () => {
-    const dto: CreateDailyNotification = { time: '09:00', timezoneOffset: 0 } as any;
-    repo.create.mockImplementation((obj: any) => ({ id: 'd1', ...obj }));
-    repo.save.mockResolvedValue({ id: 'saved1' });
-
-    const result = await service.createDailyNotification(dto, 'user_id');
-
-    expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledTimes(1);
-    const calledWith = scheduler.calculateNextNotificationTime.mock.calls[0][0];
-    expect(calledWith.user).toEqual({ id: 'user_id' });
-    expect(calledWith.type).toEqual(ReportNotificationEnum.DAILY);
-    expect(repo.save).toHaveBeenCalledWith(
-      expect.objectContaining({
-        time: '09:00',
-        timezoneOffset: 0,
-      }),
-    );
-    expect(result.id).toBe('saved1');
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
-  it('creates weekly notification and calls scheduler with dayOfWeek', async () => {
-    const dto: CreateWeeklyNotification = {
-      time: '10:00',
-      timezoneOffset: -60,
-      dayOfWeek: 1,
-    } as any;
-    repo.create.mockImplementation((obj: any) => ({ id: 'w1', ...obj }));
-    repo.save.mockResolvedValue({ id: 'savedW' });
+  describe('createDailyNotification', () => {
+    it('creates daily notification and calls scheduler with correct entity', async () => {
+      // Arrange
+      const dto: CreateDailyNotification = { time: '09:00', timezoneOffset: 0 } as any;
+      jest.spyOn(repository, 'create').mockReturnValue(validDailyNotification);
+      jest.spyOn(repository, 'save').mockResolvedValue(validDailyNotification);
 
-    const result = await service.createWeeklyNotification(dto, 'user_id');
+      // Act
+      await service.createDailyNotification(dto, validDailyNotification.user.id);
 
-    expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledTimes(1);
-    const calledWith = scheduler.calculateNextNotificationTime.mock.calls[0][0];
-    expect(calledWith.dayOfWeek).toBe(1);
-    expect(calledWith.type).toEqual(ReportNotificationEnum.WEEKLY);
-    expect(result.id).toBe('savedW');
+      // Assert
+      expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledTimes(1);
+      expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: { id: validDailyNotification.user.id },
+          type: ReportNotificationEnum.DAILY,
+          time: dto.time,
+          timezoneOffset: dto.timezoneOffset,
+        }),
+      );
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          time: dto.time,
+          timezoneOffset: dto.timezoneOffset,
+        }),
+      );
+    });
+
+    it('throws ConflictException when save unique constraint violation occurs', async () => {
+      // Arrange
+      const dto: CreateDailyNotification = { time: '09:00', timezoneOffset: 0 } as any;
+      jest.spyOn(repository, 'create').mockReturnValue(validDailyNotification);
+      const error: any = new Error('duplicate');
+      error.code = '23505';
+      jest.spyOn(repository, 'save').mockRejectedValue(error);
+
+      // Act & Assert
+      await expect(
+        service.createDailyNotification(dto, validDailyNotification.user.id),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
   });
 
-  it('throws ConflictException when save unique constraint violation occurs', async () => {
-    const dto: CreateDailyNotification = { time: '09:00', timezoneOffset: 0 } as any;
-    repo.create.mockImplementation((obj: any) => ({ ...obj }));
-    const err: any = new Error('duplicate');
-    err.code = '23505';
-    repo.save.mockRejectedValue(err);
+  describe('createWeeklyNotification', () => {
+    it('creates weekly notification and calls scheduler with dayOfWeek', async () => {
+      // Arrange
+      const dto: CreateWeeklyNotification = {
+        time: '10:00',
+        timezoneOffset: -60,
+        dayOfWeek: DayOfWeekEnum.MONDAY,
+      } as any;
+      jest.spyOn(repository, 'create').mockReturnValue(validWeeklyNotification);
+      jest.spyOn(repository, 'save').mockResolvedValue(validWeeklyNotification);
 
-    await expect(service.createDailyNotification(dto, 'user_id')).rejects.toBeInstanceOf(
-      ConflictException,
-    );
+      // Act
+      await service.createWeeklyNotification(dto, validWeeklyNotification.user.id);
+
+      // Assert
+      expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledTimes(1);
+      expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: { id: validWeeklyNotification.user.id },
+          type: ReportNotificationEnum.WEEKLY,
+          time: dto.time,
+          dayOfWeek: dto.dayOfWeek,
+          timezoneOffset: dto.timezoneOffset,
+        }),
+      );
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          time: dto.time,
+          timezoneOffset: dto.timezoneOffset,
+        }),
+      );
+    });
   });
 
-  it('throws NotFoundException when updating non-existing notification', async () => {
-    repo.findOne.mockResolvedValue(undefined);
-    await expect(
-      service.updateDailyNotification({ time: '09:00', timezoneOffset: 0 } as any, 'u'),
-    ).rejects.toBeInstanceOf(NotFoundException);
+  describe('updateDailyNotification', () => {
+    it('throws NotFoundException when updating non-existing notification', async () => {
+      // Arrange
+      jest.spyOn(repository, 'findOne').mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        service.updateDailyNotification(
+          { time: '09:00', timezoneOffset: 0 } as CreateDailyNotification,
+          '8167a958-5d55-476a-8bd2-f5fcdb8e9c5b',
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(repository.save).not.toHaveBeenCalled();
+      expect(scheduler.calculateNextNotificationTime).not.toHaveBeenCalled();
+    });
+
+    it('updates notification and calls scheduler with updated entity', async () => {
+      // Arrange
+      jest
+        .spyOn(repository, 'findOne')
+        .mockReturnValue(Promise.resolve(validDailyNotification as any));
+      jest.spyOn(repository, 'save').mockResolvedValue(validDailyNotification);
+      const dto = { time: '11:00', timezoneOffset: 60 } as CreateDailyNotification;
+
+      // Act
+      await service.updateDailyNotification(dto, validDailyNotification.user.id);
+
+      // Assert
+      expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: { id: validDailyNotification.user.id },
+          time: dto.time,
+          timezoneOffset: dto.timezoneOffset,
+          type: ReportNotificationEnum.DAILY,
+        }),
+      );
+    });
   });
 
-  it('updates notification and calls scheduler with updated entity', async () => {
-    const existing = {
-      id: 'n1',
-      user: { id: 'u' },
-      type: ReportNotificationEnum.DAILY,
-      time: '08:00',
-      timezoneOffset: 0,
-    };
-    repo.findOne.mockResolvedValue(existing);
-    repo.save.mockImplementation(async (e: any) => ({ ...e, id: 'n1' }));
-    const dto = { time: '11:00', timezoneOffset: 60 } as any;
+  describe('getBothNotifications', () => {
+    it('getBothNotifications returns daily and weekly correctly', async () => {
+      // Arrange
+      jest
+        .spyOn(repository, 'findBy')
+        .mockResolvedValue([validDailyNotification, validWeeklyNotification]);
 
-    const res = await service.updateDailyNotification(dto, 'user_id');
-
-    expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledWith(
-      expect.objectContaining({
-        user: { id: 'u' },
-        time: '11:00',
-      }),
-    );
-    expect(res.id).toBe('n1');
+      // Act
+      const res = await service.getBothNotifications('u');
+      expect(res.daily).toBe(validDailyNotification);
+      expect(res.weekly).toBe(validWeeklyNotification);
+    });
   });
 
-  it('throws NotFoundException when deleting non-existing notification', async () => {
-    repo.delete.mockResolvedValue({ affected: 0 });
-    await expect(service.deleteDailyNotification('u')).rejects.toBeInstanceOf(NotFoundException);
-  });
+  describe('updateBothNotifications', () => {
+    it('updateBothNotifications creates missing notifications and calls scheduler twice', async () => {
+      // Arrange
+      jest.spyOn(repository, 'findBy').mockResolvedValue([]);
+      // Return daily notification even for weekly time Create and Save
+      jest.spyOn(repository, 'create').mockReturnValue(validDailyNotification);
+      jest.spyOn(repository, 'save').mockReturnValue(Promise.resolve(validDailyNotification));
 
-  it('getBothNotifications returns daily and weekly correctly', async () => {
-    const daily = { id: 'd', type: ReportNotificationEnum.DAILY } as any;
-    const weekly = { id: 'w', type: ReportNotificationEnum.WEEKLY } as any;
-    repo.findBy.mockResolvedValue([daily, weekly]);
+      const dto = {
+        daily: { time: '09:00', timezoneOffset: 0 },
+        weekly: { time: '10:00', timezoneOffset: 0, dayOfWeek: 2 },
+      } as any;
 
-    const res = await service.getBothNotifications('u');
-    expect(res.daily).toBe(daily);
-    expect(res.weekly).toBe(weekly);
-  });
+      // Act
+      const res = await service.updateBothNotifications(dto, validDailyNotification.user.id);
 
-  it('updateBothNotifications creates missing notifications and calls scheduler twice', async () => {
-    repo.findBy.mockResolvedValue([]);
-    repo.create.mockImplementation((obj: any) => ({ ...obj }));
-    repo.save.mockResolvedValue({ id: 'saved' });
-    const dto = {
-      daily: { time: '09:00', timezoneOffset: 0 },
-      weekly: { time: '10:00', timezoneOffset: 0, dayOfWeek: 2 },
-    } as any;
-
-    const res = await service.updateBothNotifications(dto, 'user_id');
-
-    expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledTimes(2);
-    expect(res.daily).toBeDefined();
-    expect(res.weekly).toBeDefined();
+      // Assert
+      expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledTimes(2);
+      expect(res.daily).toBeDefined();
+      expect(res.weekly).toBeDefined();
+    });
   });
 });

--- a/src/modules/notification/notification.service.spec.ts
+++ b/src/modules/notification/notification.service.spec.ts
@@ -1,0 +1,136 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { NotificationService } from './notification.service';
+import { ReportNotificationEnum } from './enums/report-notification.enum';
+import { CreateDailyNotification } from './dtos/create-daily-notification.dto';
+import { CreateWeeklyNotification } from './dtos/create-weekly-notification.dto';
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+  let repo: any;
+  let scheduler: any;
+
+  beforeEach(() => {
+    repo = {
+      findBy: jest.fn(),
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+    };
+    scheduler = {
+      calculateNextNotificationTime: jest.fn().mockReturnValue(new Date('2025-01-01T00:00:00Z')),
+    };
+    service = new NotificationService(repo as any, scheduler as any);
+  });
+
+  it('creates daily notification and calls scheduler with correct entity', async () => {
+    const dto: CreateDailyNotification = { time: '09:00', timezoneOffset: 0 } as any;
+    repo.create.mockImplementation((obj: any) => ({ id: 'd1', ...obj }));
+    repo.save.mockResolvedValue({ id: 'saved1' });
+
+    const result = await service.createDailyNotification(dto, 'user_id');
+
+    expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledTimes(1);
+    const calledWith = scheduler.calculateNextNotificationTime.mock.calls[0][0];
+    expect(calledWith.user).toEqual({ id: 'user_id' });
+    expect(calledWith.type).toEqual(ReportNotificationEnum.DAILY);
+    expect(repo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        time: '09:00',
+        timezoneOffset: 0,
+      }),
+    );
+    expect(result.id).toBe('saved1');
+  });
+
+  it('creates weekly notification and calls scheduler with dayOfWeek', async () => {
+    const dto: CreateWeeklyNotification = {
+      time: '10:00',
+      timezoneOffset: -60,
+      dayOfWeek: 1,
+    } as any;
+    repo.create.mockImplementation((obj: any) => ({ id: 'w1', ...obj }));
+    repo.save.mockResolvedValue({ id: 'savedW' });
+
+    const result = await service.createWeeklyNotification(dto, 'user_id');
+
+    expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledTimes(1);
+    const calledWith = scheduler.calculateNextNotificationTime.mock.calls[0][0];
+    expect(calledWith.dayOfWeek).toBe(1);
+    expect(calledWith.type).toEqual(ReportNotificationEnum.WEEKLY);
+    expect(result.id).toBe('savedW');
+  });
+
+  it('throws ConflictException when save unique constraint violation occurs', async () => {
+    const dto: CreateDailyNotification = { time: '09:00', timezoneOffset: 0 } as any;
+    repo.create.mockImplementation((obj: any) => ({ ...obj }));
+    const err: any = new Error('duplicate');
+    err.code = '23505';
+    repo.save.mockRejectedValue(err);
+
+    await expect(service.createDailyNotification(dto, 'user_id')).rejects.toBeInstanceOf(
+      ConflictException,
+    );
+  });
+
+  it('throws NotFoundException when updating non-existing notification', async () => {
+    repo.findOne.mockResolvedValue(undefined);
+    await expect(
+      service.updateDailyNotification({ time: '09:00', timezoneOffset: 0 } as any, 'u'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('updates notification and calls scheduler with updated entity', async () => {
+    const existing = {
+      id: 'n1',
+      user: { id: 'u' },
+      type: ReportNotificationEnum.DAILY,
+      time: '08:00',
+      timezoneOffset: 0,
+    };
+    repo.findOne.mockResolvedValue(existing);
+    repo.save.mockImplementation(async (e: any) => ({ ...e, id: 'n1' }));
+    const dto = { time: '11:00', timezoneOffset: 60 } as any;
+
+    const res = await service.updateDailyNotification(dto, 'user_id');
+
+    expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: { id: 'u' },
+        time: '11:00',
+      }),
+    );
+    expect(res.id).toBe('n1');
+  });
+
+  it('throws NotFoundException when deleting non-existing notification', async () => {
+    repo.delete.mockResolvedValue({ affected: 0 });
+    await expect(service.deleteDailyNotification('u')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('getBothNotifications returns daily and weekly correctly', async () => {
+    const daily = { id: 'd', type: ReportNotificationEnum.DAILY } as any;
+    const weekly = { id: 'w', type: ReportNotificationEnum.WEEKLY } as any;
+    repo.findBy.mockResolvedValue([daily, weekly]);
+
+    const res = await service.getBothNotifications('u');
+    expect(res.daily).toBe(daily);
+    expect(res.weekly).toBe(weekly);
+  });
+
+  it('updateBothNotifications creates missing notifications and calls scheduler twice', async () => {
+    repo.findBy.mockResolvedValue([]);
+    repo.create.mockImplementation((obj: any) => ({ ...obj }));
+    repo.save.mockResolvedValue({ id: 'saved' });
+    const dto = {
+      daily: { time: '09:00', timezoneOffset: 0 },
+      weekly: { time: '10:00', timezoneOffset: 0, dayOfWeek: 2 },
+    } as any;
+
+    const res = await service.updateBothNotifications(dto, 'user_id');
+
+    expect(scheduler.calculateNextNotificationTime).toHaveBeenCalledTimes(2);
+    expect(res.daily).toBeDefined();
+    expect(res.weekly).toBeDefined();
+  });
+});

--- a/src/modules/users/user-code-verification.service.spec.ts
+++ b/src/modules/users/user-code-verification.service.spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { UserCodeVerificationService } from './user-code-verification.service';
+import { Repository } from 'typeorm';
+import { UserRole } from './enums/user-role.enum';
+import { UserCodeVerification } from './entities/user.code.verification.entity';
+import { EmailSenderService } from '../email-sender/email-sender.service';
+
+describe('UserCodeVerificationService', () => {
+  let service: UserCodeVerificationService;
+  let repository: Repository<UserCodeVerification>;
+  let userRepository: Repository<User>;
+  let emailSender: EmailSenderService;
+
+  const validUser = {
+    id: '8167a958-5d55-476a-8bd2-f5fcdb8e9c5b',
+    email: 'user@email.com',
+    role: UserRole.USER,
+  } as User;
+
+  const validUserCode = {
+    id: '72abcf90-5d55-476a-8bd2-f5fcdb8e9c5b',
+    code: '000000',
+    user: validUser,
+    process: 'USER_SIGNUP',
+  } as UserCodeVerification;
+
+  beforeEach(async () => {
+    const userRepositoryMock = {
+      findOne: jest.fn().mockImplementation(() => Promise.resolve(validUser)),
+      findOneBy: jest.fn().mockImplementation(() => Promise.resolve(validUser)),
+      save: jest.fn().mockImplementation(() => Promise.resolve(validUser)),
+      remove: jest.fn().mockImplementation(() => Promise.resolve(validUser)),
+    };
+
+    const repositoryMock = {
+      create: jest.fn().mockImplementation(() => validUserCode),
+      save: jest.fn().mockImplementation(() => validUserCode),
+    };
+
+    const emailSenderMock = {
+      sendVerificationEmail: jest.fn(),
+    };
+
+    const repositoryToken = getRepositoryToken(UserCodeVerification);
+    const userRepositoryToken = getRepositoryToken(User);
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserCodeVerificationService,
+        { provide: repositoryToken, useValue: repositoryMock },
+        { provide: userRepositoryToken, useValue: userRepositoryMock },
+        { provide: EmailSenderService, useValue: emailSenderMock },
+      ],
+    }).compile();
+
+    service = module.get<UserCodeVerificationService>(UserCodeVerificationService);
+    emailSender = module.get<EmailSenderService>(EmailSenderService);
+    repository = module.get<Repository<UserCodeVerification>>(repositoryToken);
+    userRepository = module.get<Repository<User>>(userRepositoryToken);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+    expect(emailSender).toBeDefined();
+    expect(repository).toBeDefined();
+    expect(userRepository).toBeDefined();
+  });
+
+  it('should save verification code', async () => {
+    expect(await service.createVerificationCode(validUser.email, validUserCode.process)).toEqual(
+      validUserCode.code,
+    );
+    expect(repository.save).toHaveBeenCalledWith(validUserCode);
+  });
+
+  it('should throw exception when user is invalid', async () => {
+    jest.spyOn(userRepository, 'findOne').mockImplementation(() => null);
+    expect(
+      async () => await service.createVerificationCode(validUser.email, validUserCode.process),
+    ).rejects.toThrow();
+    expect(repository.save).toHaveBeenCalledTimes(0);
+  });
+
+  it('should save and send verification code', async () => {
+    await service.createAndSendVerificationCode(validUser.email, validUserCode.process);
+
+    expect(repository.save).toHaveBeenCalledWith(validUserCode);
+    expect(emailSender.sendVerificationEmail).toHaveBeenCalledWith(
+      validUser.email,
+      validUserCode.code,
+    );
+  });
+
+  it('should not send verification code when user is invalid', async () => {
+    jest.spyOn(userRepository, 'findOne').mockImplementation(() => null);
+    expect(
+      async () =>
+        await service.createAndSendVerificationCode(validUser.email, validUserCode.process),
+    ).rejects.toThrow();
+    expect(repository.save).toHaveBeenCalledTimes(0);
+    expect(emailSender.sendVerificationEmail).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/modules/users/user-code-verification.service.spec.ts
+++ b/src/modules/users/user-code-verification.service.spec.ts
@@ -60,6 +60,10 @@ describe('UserCodeVerificationService', () => {
     userRepository = module.get<Repository<User>>(userRepositoryToken);
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should be defined', () => {
     expect(service).toBeDefined();
     expect(emailSender).toBeDefined();
@@ -67,38 +71,51 @@ describe('UserCodeVerificationService', () => {
     expect(userRepository).toBeDefined();
   });
 
-  it('should save verification code', async () => {
-    expect(await service.createVerificationCode(validUser.email, validUserCode.process)).toEqual(
-      validUserCode.code,
-    );
-    expect(repository.save).toHaveBeenCalledWith(validUserCode);
+  describe('createVerificationCode', () => {
+    it('should save verification code', async () => {
+      // Arrange & Act & Assert
+      expect(await service.createVerificationCode(validUser.email, validUserCode.process)).toEqual(
+        validUserCode.code,
+      );
+      expect(repository.save).toHaveBeenCalledWith(validUserCode);
+    });
+
+    it('should throw exception when user is invalid', async () => {
+      // Arrange
+      jest.spyOn(userRepository, 'findOne').mockImplementation(() => null);
+
+      // Act & Assert
+      expect(
+        async () => await service.createVerificationCode(validUser.email, validUserCode.process),
+      ).rejects.toThrow();
+      expect(repository.save).toHaveBeenCalledTimes(0);
+    });
   });
 
-  it('should throw exception when user is invalid', async () => {
-    jest.spyOn(userRepository, 'findOne').mockImplementation(() => null);
-    expect(
-      async () => await service.createVerificationCode(validUser.email, validUserCode.process),
-    ).rejects.toThrow();
-    expect(repository.save).toHaveBeenCalledTimes(0);
-  });
+  describe('createAndSendVerificationCode', () => {
+    it('should save and send verification code', async () => {
+      // Arrange & Act
+      await service.createAndSendVerificationCode(validUser.email, validUserCode.process);
 
-  it('should save and send verification code', async () => {
-    await service.createAndSendVerificationCode(validUser.email, validUserCode.process);
+      // Assert
+      expect(repository.save).toHaveBeenCalledWith(validUserCode);
+      expect(emailSender.sendVerificationEmail).toHaveBeenCalledWith(
+        validUser.email,
+        validUserCode.code,
+      );
+    });
 
-    expect(repository.save).toHaveBeenCalledWith(validUserCode);
-    expect(emailSender.sendVerificationEmail).toHaveBeenCalledWith(
-      validUser.email,
-      validUserCode.code,
-    );
-  });
+    it('should not send verification code when user is invalid', async () => {
+      // Arrange & Act
+      jest.spyOn(userRepository, 'findOne').mockImplementation(() => null);
 
-  it('should not send verification code when user is invalid', async () => {
-    jest.spyOn(userRepository, 'findOne').mockImplementation(() => null);
-    expect(
-      async () =>
-        await service.createAndSendVerificationCode(validUser.email, validUserCode.process),
-    ).rejects.toThrow();
-    expect(repository.save).toHaveBeenCalledTimes(0);
-    expect(emailSender.sendVerificationEmail).toHaveBeenCalledTimes(0);
+      // Assert
+      expect(
+        async () =>
+          await service.createAndSendVerificationCode(validUser.email, validUserCode.process),
+      ).rejects.toThrow();
+      expect(repository.save).toHaveBeenCalledTimes(0);
+      expect(emailSender.sendVerificationEmail).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/src/modules/users/users.controller.spec.ts
+++ b/src/modules/users/users.controller.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { UserMapper } from './users.mapper';
+import { UserCodeVerificationService } from './user-code-verification.service';
+
+describe('UsersController', () => {
+  let controller: UsersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: UsersService, useValue: {} },
+        { provide: UserMapper, useValue: {} },
+        { provide: UserCodeVerificationService, useValue: {} },
+      ],
+      controllers: [UsersController],
+    }).compile();
+
+    controller = module.get<UsersController>(UsersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -49,6 +49,10 @@ describe('UsersService', () => {
     repository = module.get<Repository<User>>(repositoryToken);
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should be defined', () => {
     expect(service).toBeDefined();
   });

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersService } from './users.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { BoardsService } from '../boards/boards.service';
+import { UserCodeVerificationService } from './user-code-verification.service';
+import { Repository } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { UserRole } from './enums/user-role.enum';
+import { AppwriteUploadsService } from '../appwrite-uploads/appwrite-uploads.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let repository: Repository<User>;
+  let userCodeVerificationServiceMock: UserCodeVerificationService;
+
+  const validUser = {
+    id: '8167a958-5d55-476a-8bd2-f5fcdb8e9c5b',
+    email: 'user@email.com',
+    role: UserRole.USER,
+  } as User;
+
+  beforeEach(async () => {
+    const repositoryMock = {
+      findOneBy: jest.fn().mockImplementation(() => Promise.resolve(validUser)),
+      save: jest.fn().mockImplementation(() => Promise.resolve(validUser)),
+      remove: jest.fn().mockImplementation(() => Promise.resolve(validUser)),
+    };
+
+    const appwriteMock = {
+      uploadFile: jest.fn().mockImplementation(() => Promise.resolve()),
+    };
+
+    const repositoryToken = getRepositoryToken(User);
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: repositoryToken, useValue: repositoryMock },
+        { provide: UserCodeVerificationService, useValue: { verifyUserCode: jest.fn() } },
+        { provide: BoardsService, useValue: {} },
+        { provide: AppwriteUploadsService, useValue: appwriteMock },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+    userCodeVerificationServiceMock = module.get<UserCodeVerificationService>(
+      UserCodeVerificationService,
+    );
+    repository = module.get<Repository<User>>(repositoryToken);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should find a user', async () => {
+    // Act & Assert
+    expect(await service.findOneBy({ email: validUser.email })).toEqual({
+      id: validUser.id,
+      email: validUser.email,
+      role: validUser.role,
+    });
+  });
+
+  it('should throw NotFoundException', async () => {
+    // Arrange
+    jest.spyOn(repository, 'findOneBy').mockImplementation(() => null);
+
+    // Act & Assert
+    expect(() => service.findOneBy({ email: 'user@email.com' })).toThrow(NotFoundException);
+  });
+
+  it('should update user', async () => {
+    // Act
+    await service.update(
+      validUser.id,
+      {
+        role: UserRole.ADMIN,
+        profilePicUrl: null,
+      },
+      null,
+    );
+
+    // Assert
+    expect(repository.save).toHaveBeenCalledWith({ ...validUser, role: UserRole.ADMIN });
+  });
+
+  it('should delete user', async () => {
+    // Act
+    await service.remove(validUser.id, 'code');
+
+    // Assert
+    expect(repository.remove).toHaveBeenCalledWith(validUser);
+  });
+
+  it('should throw exception on delete user', async () => {
+    // Arrange
+    jest
+      .spyOn(userCodeVerificationServiceMock, 'verifyUserCode')
+      .mockImplementation(() => Promise.reject(new Error('unit test error')));
+
+    // Act & Assert
+    expect(async () => await service.remove(validUser.id, 'some code')).rejects.toThrow();
+    expect(repository.remove).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/utils/array.extensions.ts
+++ b/src/utils/array.extensions.ts
@@ -10,6 +10,8 @@ if (!Array.prototype.containsDuplicates) {
     const uniqueSet = new Set(this);
     return this.length !== uniqueSet.size;
   };
+}
+if (!Array.prototype.equals) {
   Array.prototype.equals = function <T>(this: Array<T>, arrayTarget: Array<T>) {
     const set1 = new Set(this);
     const set2 = new Set(arrayTarget);


### PR DESCRIPTION
Implemented unit tests for most `service` files.
Some files might have different styles because most of them were generated. I plan to update such files later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved error handling when rearranging board columns with none present.
  - Increased sign-in robustness for missing users.
  - Stabilized array utility initialization to avoid duplicate method definitions.
- Tests
  - Added extensive unit tests across authentication, boards, board columns, companies, documents, job applications and notes, notifications, and users, plus basic controller instantiation checks.
  - Enhanced Jest setup to load shared test utilities.
- Chores
  - Introduced a CI workflow to run unit tests on pushes and pull requests.
- Refactor
  - Minor import path and non-functional cleanups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->