### PR TITLE
Added board name for email report

### DIFF
--- a/src/modules/notification/notification-scheduler.service.spec.ts
+++ b/src/modules/notification/notification-scheduler.service.spec.ts
@@ -26,6 +26,7 @@ describe('NotificationSchedulerService', () => {
         {
           id: '9f62c332-6b21-495e-be44-ff5c8df0d5c1',
           isArchived: false,
+          name: 'Test Board',
           columns: [
             {
               id: '39d7528f-ebaf-4bff-9586-5963740534d1',
@@ -93,7 +94,7 @@ describe('NotificationSchedulerService', () => {
       expect(emailSender.sendEmail).toHaveBeenCalledTimes(1);
       expect(emailSender.sendEmail).toHaveBeenCalledWith(
         validNotification.user.email,
-        'Your Job Tracker Daily Report',
+        `Your Job Tracker Daily Report for ${validNotification.user.board[0].name}`,
         expect.any(String),
       );
       expect((service as any).calculateNextNotificationTime).toHaveBeenCalledWith(

--- a/src/modules/notification/notification-scheduler.service.ts
+++ b/src/modules/notification/notification-scheduler.service.ts
@@ -43,14 +43,13 @@ export class NotificationSchedulerService {
         const email = this.generateJobsHtmlPage(
           reportData,
           board.id,
-          board.name,
           notification.user.firstName,
           hour,
           notification.type,
         );
         await this.emailSenderService.sendEmail(
           notification.user.email,
-          `Your Job Tracker ${reportType} Report`,
+          `Your Job Tracker ${reportType} Report for ${board.name}`,
           email,
         );
       }
@@ -173,7 +172,6 @@ export class NotificationSchedulerService {
   generateJobsHtmlPage(
     reportData: Record<JobApplicationStatus, Array<JobApplication>>,
     boardId: string,
-    boardName: string,
     userName: string,
     notificationTime: number,
     reportType: ReportNotificationType,
@@ -239,7 +237,7 @@ export class NotificationSchedulerService {
           ? 'afternoon'
           : 'evening';
     html += `<h1>Good ${dayPart} ${userName}!</h1>`;
-    html += `<h3>Here is your '${boardName}' ${reportType.toLowerCase()} job report for ${formatDate(new Date())}.</h3><br>`;
+    html += `<h3>Here is your ${reportType.toLowerCase()} job report for ${formatDate(new Date())}.</h3><br>`;
 
     if (reportData[JobApplicationStatus.Deadline].length) {
       html += `<h2>Past Due Activities</h2><div class="card"><table class="table"><tbody>`;

--- a/src/modules/notification/notification-scheduler.service.ts
+++ b/src/modules/notification/notification-scheduler.service.ts
@@ -43,6 +43,7 @@ export class NotificationSchedulerService {
         const email = this.generateJobsHtmlPage(
           reportData,
           board.id,
+          board.name,
           notification.user.firstName,
           hour,
           notification.type,
@@ -172,6 +173,7 @@ export class NotificationSchedulerService {
   generateJobsHtmlPage(
     reportData: Record<JobApplicationStatus, Array<JobApplication>>,
     boardId: string,
+    boardName: string,
     userName: string,
     notificationTime: number,
     reportType: ReportNotificationType,
@@ -237,7 +239,7 @@ export class NotificationSchedulerService {
           ? 'afternoon'
           : 'evening';
     html += `<h1>Good ${dayPart} ${userName}!</h1>`;
-    html += `<h3>Here is your ${reportType.toLowerCase()} job report for ${formatDate(new Date())}.</h3><br>`;
+    html += `<h3>Here is your '${boardName}' ${reportType.toLowerCase()} job report for ${formatDate(new Date())}.</h3><br>`;
 
     if (reportData[JobApplicationStatus.Deadline].length) {
       html += `<h2>Past Due Activities</h2><div class="card"><table class="table"><tbody>`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Email subjects for scheduled notifications now include the board name (e.g., “Your Job Tracker Daily Report for [Board Name]”) to provide clearer context, especially when receiving reports from multiple boards. No changes to scheduling or delivery behavior.
* Tests
  * Updated test data and assertions to align with the new subject format, ensuring coverage for board-specific subjects without altering production logic or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->