### PR TITLE
fix: increase the JSON body parser limit to 10mb

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-04-23
+
+### Fixed
+
+- **Request Body Size Limit**: Increased the JSON body size limit from the default 100kb to 10mb to prevent `413 Request Entity Too Large` errors when creating or editing notes with large rich-text (HTML) content.
+  - **Root Cause**: NestJS/Express applies a 100kb default body parser limit with no explicit override configured.
+  - **Fix**: Disabled NestJS's built-in body parser (`bodyParser: false`) and registered a single authoritative `express.json({ limit: '10mb' })` parser to avoid middleware duplication.
+  - **Impact**: Notes (and all other endpoints) now accept request bodies up to 10mb; all existing functionality is unaffected.
+  - **File**: `src/main.ts`
+
 ## [1.1.0] - 2026-02-08
 
 ### Added - Logo Backfill & Integration

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Request Body Size Limit**: Increased the JSON body size limit from the default 100kb to 10mb to prevent `413 Request Entity Too Large` errors when creating or editing notes with large rich-text (HTML) content.
   - **Root Cause**: NestJS/Express applies a 100kb default body parser limit with no explicit override configured.
-  - **Fix**: Disabled NestJS's built-in body parser (`bodyParser: false`) and registered a single authoritative `express.json({ limit: '10mb' })` parser to avoid middleware duplication.
+  - **Fix**: Disabled NestJS's built-in body parser (`bodyParser: false`) and registered explicit `express.json({ limit: '10mb' })` and `express.urlencoded({ limit: '10mb', extended: true })` parsers to avoid middleware duplication.
   - **Impact**: Notes (and all other endpoints) now accept request bodies up to 10mb; all existing functionality is unaffected.
   - **File**: `src/main.ts`
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,13 @@ import { CacheControlMiddleware } from './cache-control.middleware';
 const expressServer = express();
 
 const createNestServer = async (expressInstance: express.Express) => {
-  const app = await NestFactory.create(AppModule, new ExpressAdapter(expressInstance));
+  const app = await NestFactory.create(AppModule, new ExpressAdapter(expressInstance), {
+    bodyParser: false, // Disable default 100kb limit; we register our own below
+  });
+
+  // Allow up to 10mb for JSON bodies (needed for rich-text note content)
+  app.use(express.json({ limit: '10mb' }));
+  app.use(express.urlencoded({ limit: '10mb', extended: true }));
 
   app.enableCors({
     credentials: true,


### PR DESCRIPTION
When the user copy/paste a huge amount of text into the Notes or Job Description the request failed with error code 413 - `Payload Too Large`. So the normal JSON body parser in Express.js has a limit of 100kB. This PR increase the limit to 10MB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased maximum request body size from 100kb to 10mb, resolving errors when creating or editing notes with large rich-text content.

* **Documentation**
  * Updated changelog for version 1.1.1 documenting the request body limit improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->